### PR TITLE
feat(catalog): aliases, registry+tag shorthand, alphabetize, collapsed tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,20 @@
 
 ## Installing
 
-Download the latest Flatpak bundle from the [Continuous Build release](https://github.com/tuna-os/tuna-installer/releases/tag/continuous):
-
-| Bundle | Description |
-|---|---|
-| `org.bootcinstaller.Installer.flatpak` | Production build |
-| `org.bootcinstaller.Installer.Devel.flatpak` | Debug build — full verbose logging to `~/.cache/tuna-installer/installer-debug.log` |
+### Production
 
 ```bash
-flatpak install --user --bundle org.bootcinstaller.Installer.flatpak
+curl -Lo installer.flatpak \
+  https://github.com/tuna-os/tuna-installer/releases/download/continuous/org.bootcinstaller.Installer.flatpak \
+  && flatpak install --user --bundle installer.flatpak
 ```
 
-Or in one line:
+### Devel (latest `dev` branch build)
 
 ```bash
-curl -Lo tuna-installer.flatpak \
-  https://github.com/tuna-os/tuna-installer/releases/download/continuous/org.bootcinstaller.Installer.flatpak \
-  && flatpak install --user --bundle tuna-installer.flatpak
+curl -Lo installer-devel.flatpak \
+  https://github.com/tuna-os/tuna-installer/releases/download/continuous-dev/org.bootcinstaller.Installer.Devel.flatpak \
+  && flatpak install --user --bundle installer-devel.flatpak
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```bash
 curl -Lo installer.flatpak \
   https://github.com/tuna-os/tuna-installer/releases/download/continuous/org.bootcinstaller.Installer.flatpak \
-  && flatpak install --user --bundle installer.flatpak
+  && flatpak uninstall --user -y org.bootcinstaller.Installer 2>/dev/null; flatpak install --user --bundle -y installer.flatpak
 ```
 
 ### Devel (latest `dev` branch build)
@@ -20,7 +20,7 @@ curl -Lo installer.flatpak \
 ```bash
 curl -Lo installer-devel.flatpak \
   https://github.com/tuna-os/tuna-installer/releases/download/continuous-dev/org.bootcinstaller.Installer.Devel.flatpak \
-  && flatpak install --user --bundle installer-devel.flatpak
+  && flatpak uninstall --user -y org.bootcinstaller.Installer.Devel 2>/dev/null; flatpak install --user --bundle -y installer-devel.flatpak
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```bash
 curl -Lo installer.flatpak \
   https://github.com/tuna-os/tuna-installer/releases/download/continuous/org.bootcinstaller.Installer.flatpak \
-  && flatpak uninstall --user -y org.bootcinstaller.Installer 2>/dev/null; flatpak install --user --bundle -y installer.flatpak
+  && sudo flatpak uninstall -y org.bootcinstaller.Installer org.tunaos.Installer 2>/dev/null; sudo flatpak install --bundle -y installer.flatpak
 ```
 
 ### Devel (latest `dev` branch build)
@@ -20,7 +20,7 @@ curl -Lo installer.flatpak \
 ```bash
 curl -Lo installer-devel.flatpak \
   https://github.com/tuna-os/tuna-installer/releases/download/continuous-dev/org.bootcinstaller.Installer.Devel.flatpak \
-  && flatpak uninstall --user -y org.bootcinstaller.Installer.Devel 2>/dev/null; flatpak install --user --bundle -y installer-devel.flatpak
+  && sudo flatpak uninstall -y org.bootcinstaller.Installer.Devel 2>/dev/null; sudo flatpak install --bundle -y installer-devel.flatpak
 ```
 
 ---

--- a/bootc_installer/defaults/image.py
+++ b/bootc_installer/defaults/image.py
@@ -98,7 +98,45 @@ def _load_manifest():
         return {"fallback_flatpaks": [], "images": []}
 
 
+def _resolve_aliases(obj: object, aliases: dict) -> None:
+    """Recursively replace ``@alias_name`` strings with values from *aliases*.
+
+    Any string value (in a dict or list) that starts with ``@`` is treated as
+    an alias reference.  Unknown aliases are left as-is so the parser can
+    surface a meaningful error later rather than silently corrupting data.
+
+    This runs once at manifest-load time so the rest of the codebase never
+    needs to know about the alias syntax.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, str) and value.startswith("@"):
+                resolved = aliases.get(value[1:])
+                if resolved is not None:
+                    obj[key] = resolved
+                else:
+                    logger.warning(f"images.json: unknown alias '{value}'")
+            else:
+                _resolve_aliases(value, aliases)
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            if isinstance(value, str) and value.startswith("@"):
+                resolved = aliases.get(value[1:])
+                if resolved is not None:
+                    obj[i] = resolved
+                else:
+                    logger.warning(f"images.json: unknown alias '{value}'")
+            else:
+                _resolve_aliases(value, aliases)
+
+
 _MANIFEST = _load_manifest()
+
+# Resolve @alias references before anything else reads the manifest.
+_aliases = _MANIFEST.get("aliases", {})
+if _aliases:
+    _resolve_aliases(_MANIFEST, _aliases)
+
 _IMAGE_TREE = _MANIFEST["images"]
 _DEFAULT_IMAGE = _MANIFEST.get("default_image", "")
 _FALLBACK_FLATPAKS = _MANIFEST["fallback_flatpaks"]
@@ -296,9 +334,9 @@ class VanillaDefaultImage(Adw.Bin):
                     img.get("description", ""), "", [exp])
             self.list_images.append(exp)
 
-    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx=""):
+    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx="", registry_ctx=""):
         """Recursively build ExpanderRow groups and ActionRow leaves."""
-        # Inherit flatpaks, icon, carousel, needs_user_creation, composefs, image_type, bootloader, image_filesystem, and flatpak_var_path from nearest ancestor.
+        # Inherit flatpaks, icon, carousel, needs_user_creation, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, and registry from nearest ancestor.
         node_flatpaks = node.get("flatpaks", flatpaks_ctx)
         node_icon = node.get("icon", icon_ctx)
         node_carousel = node.get("carousel", carousel_ctx)
@@ -308,9 +346,23 @@ class VanillaDefaultImage(Adw.Bin):
         node_bootloader = node.get("bootloader", bootloader_ctx)
         node_image_filesystem = node.get("filesystem", image_filesystem_ctx)
         node_flatpak_var_path = node.get("flatpak_var_path", flatpak_var_path_ctx)
+        node_registry = node.get("registry", registry_ctx)
 
-        if "imgref" in node:
-            self.__add_leaf(parent, node["name"], node["imgref"],
+        # A leaf can use "tag" instead of a full "imgref" when a "registry" is
+        # available from this node or an ancestor.  The full imgref is composed
+        # as "registry:tag" so the rest of the code never sees the shorthand.
+        imgref = node.get("imgref")
+        if imgref is None and "tag" in node:
+            if node_registry:
+                imgref = f"{node_registry}:{node['tag']}"
+            else:
+                logger.warning(
+                    f"images.json: node '{node.get('name')}' has 'tag' but no "
+                    f"'registry' in scope — skipping leaf"
+                )
+
+        if imgref is not None:
+            self.__add_leaf(parent, node["name"], imgref,
                             node.get("desc", ""), search_ctx, ancestors,
                             node_flatpaks, node_icon, node_carousel, node_needs_user,
                             node_composefs, node_image_type, node_bootloader, node_image_filesystem,
@@ -336,7 +388,7 @@ class VanillaDefaultImage(Adw.Bin):
         child_ancestors = ancestors + [exp]
 
         for child in node.get("children", []):
-            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path)
+            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path, node_registry)
 
         if parent is self.list_images:
             parent.append(exp)

--- a/bootc_installer/defaults/image.py
+++ b/bootc_installer/defaults/image.py
@@ -280,7 +280,7 @@ class VanillaDefaultImage(Adw.Bin):
         self.__step = step
         self.delta = False
 
-        self.__selected_imgref = _DEFAULT_IMAGE
+        self.__selected_imgref = _DEFAULT_IMAGE or None
         self.__selected_flatpaks = None  # per-image flatpak list (None = use fallback)
         self.__selected_flatpak_var_path = ""  # override for writable var path (e.g. GnomeOS)
         self.__selected_carousel = None  # per-image carousel slides (None = use recipe default)

--- a/bootc_installer/gtk/default-disk.blp
+++ b/bootc_installer/gtk/default-disk.blp
@@ -13,6 +13,7 @@ template $VanillaDefaultDisk: Adw.Bin {
     [overlay]
     Button btn_next {
       visible: false;
+      sensitive: false;
       margin-end: 12;
       margin-start: 12;
       icon-name: "go-next-symbolic";

--- a/bootc_installer/utils/processor.py
+++ b/bootc_installer/utils/processor.py
@@ -124,7 +124,7 @@ class Processor:
         if not image:
             logger.warning("No image/imgref found in finals or sys_recipe!")
 
-        target_imgref = f"docker://{image}" if image else ""
+        target_imgref = image
 
         # --- Hostname ---
         hostname = merged.get("hostname", sys_recipe.get("hostname", "tunaos"))

--- a/bootc_installer/utils/recipe.py
+++ b/bootc_installer/utils/recipe.py
@@ -26,6 +26,7 @@ logger = logging.getLogger("Installer::RecipeLoader")
 
 class RecipeLoader:
     recipe_paths = [
+        "/etc/bootc-installer/recipe.json",
         "/etc/tunaos-installer/recipe.json",
         "/etc/vanilla-installer/recipe.json",
         "/app/share/bootc-installer/recipe.json",

--- a/bootc_installer/windows/main_window.py
+++ b/bootc_installer/windows/main_window.py
@@ -116,7 +116,7 @@ class VanillaWindow(Adw.ApplicationWindow):
         if target is None and self.__builder.widgets:
             target = self.__builder.widgets[-1]
 
-        if target is not None:
+        if target is not None and hasattr(target, "btn_next"):
             self.__update_finals_handler = target.btn_next.connect("clicked", self.update_finals)
             self.__update_finals_widget = target
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -24,7 +24,10 @@ if repo_root not in sys.path:
 import gi  # noqa: E402
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-gi.require_version("Vte", "3.91")
+try:
+    gi.require_version("Vte", "3.91")
+except ValueError:
+    pass  # VTE not installed in this environment; tests that need it will fail at import
 
 from gi.repository import Adw, Gio  # noqa: E402
 

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -152,6 +152,32 @@ class TestImageStep:
 
 # ── Wizard navigation ──────────────────────────────────────────────────────────
 
+class TestDiskStepButtonState:
+    def test_next_button_insensitive_before_selection(self):
+        """btn_next must start insensitive so the header Next is greyed out.
+
+        Regression test: the blueprint previously omitted sensitive: false, so
+        the page btn_next defaulted to sensitive=True and the window mirrored
+        that onto the header Next button — making it clickable before any disk
+        was chosen.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from bootc_installer.defaults.disk import VanillaDefaultDisk
+
+        mock_window = MagicMock()
+        mock_window.recipe = {"min_disk_size": 51200}
+
+        with patch("bootc_installer.defaults.disk.DisksManager") as MockDM:
+            MockDM.return_value.all_disks.return_value = []
+            widget = VanillaDefaultDisk(mock_window, {}, "disk", {})
+            _pump()
+
+        assert not widget.btn_next.get_sensitive(), (
+            "btn_next must be insensitive on load so the header Next is greyed out"
+        )
+
+
 class TestWizardNavigation:
     def test_can_advance_from_image_step(self, window):
         """Clicking Next on the image step rebuilds downstream UI and advances."""

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 import tempfile
+from unittest.mock import patch as _mock_patch
 
 import pytest
 
@@ -73,12 +74,25 @@ def window():
 
     old_recipe_env = os.environ.get("VANILLA_CUSTOM_RECIPE")
     os.environ["VANILLA_CUSTOM_RECIPE"] = recipe_path
+
+    # On an ostree-booted dev machine, RecipeLoader detects "live ISO mode"
+    # and strips the image step. Patch os.path.exists in the recipe module
+    # to simulate running inside a Flatpak (/.flatpak-info present), which
+    # keeps live_iso_mode=False so the image step is retained for tests.
+    _real_exists = os.path.exists
+    def _flatpak_exists(p):
+        if p == "/.flatpak-info":
+            return True
+        return _real_exists(p)
+
     try:
         app = Adw.Application(
             application_id="org.bootcinstaller.InstallerTest",
             flags=Gio.ApplicationFlags.NON_UNIQUE,
         )
-        win = VanillaWindow(application=app)
+        with _mock_patch("bootc_installer.utils.recipe.os.path.exists",
+                         side_effect=_flatpak_exists):
+            win = VanillaWindow(application=app)
         win.present()
         _pump()
         yield win

--- a/tests/unit/test_image_helpers.py
+++ b/tests/unit/test_image_helpers.py
@@ -203,14 +203,16 @@ class TestImagesCatalogIntegrity(unittest.TestCase):
         self.assertEqual(bad, [], f"'Gaming' label found (use Nvidia+CUDA): {bad}")
 
     def test_default_image_present_and_valid(self):
-        """default_image must be set and must exist as a leaf in the tree.
+        """If default_image is set it must exist as a leaf in the tree.
 
-        Handles both explicit ``imgref`` leaves and ``registry``+``tag`` shorthand
-        nodes so refactored groups are covered.
+        An absent or empty default_image is valid — the tree starts fully
+        collapsed with nothing pre-selected (btn_next disabled until the
+        user picks an image).  Distros can override via their own images.json.
         """
         catalog = self._load_catalog()
         default = catalog.get("default_image", "")
-        self.assertTrue(default, "default_image is missing or empty in images.json")
+        if not default:
+            return  # fully-collapsed mode — no default required
 
         found = list(self._all_imgrefs(catalog.get("images", [])))
         self.assertIn(default, found,

--- a/tests/unit/test_image_helpers.py
+++ b/tests/unit/test_image_helpers.py
@@ -68,7 +68,7 @@ _mock_gio_data.get_data.return_value = _json.dumps(_FIXTURE_MANIFEST).encode()
 sys.modules["gi.repository"].Gio.resources_lookup_data.return_value = _mock_gio_data
 sys.modules["gi.repository"].Gio.ResourceLookupFlags.NONE = 0
 
-from bootc_installer.defaults.image import _find_icon_for_imgref  # noqa: E402
+from bootc_installer.defaults.image import _find_icon_for_imgref, _resolve_aliases  # noqa: E402
 
 
 class TestFindIconForImgref(unittest.TestCase):
@@ -112,8 +112,44 @@ class TestDistroInfoDefaultImageIcon(unittest.TestCase):
         self.assertTrue(icon.startswith("resource://"))
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestResolveAliases(unittest.TestCase):
+    """Unit tests for the @alias resolution helper."""
+
+    def test_string_value_replaced(self):
+        aliases = {"brew_url": "https://example.com/flatpaks.Brewfile"}
+        manifest = {"images": [{"name": "Foo", "flatpaks": "@brew_url"}]}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["images"][0]["flatpaks"], "https://example.com/flatpaks.Brewfile")
+
+    def test_list_value_replaced(self):
+        aliases = {"foo": "bar"}
+        obj = ["@foo", "baz", "@foo"]
+        _resolve_aliases(obj, aliases)
+        self.assertEqual(obj, ["bar", "baz", "bar"])
+
+    def test_non_alias_string_left_unchanged(self):
+        aliases = {"foo": "bar"}
+        manifest = {"name": "NoAlias", "flatpaks": "https://example.com/file"}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["flatpaks"], "https://example.com/file")
+
+    def test_unknown_alias_left_as_is(self):
+        aliases = {"known": "value"}
+        manifest = {"key": "@unknown"}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["key"], "@unknown")
+
+    def test_nested_dict_resolved(self):
+        aliases = {"url": "https://host/path"}
+        manifest = {"a": {"b": {"flatpaks": "@url"}}}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["a"]["b"]["flatpaks"], "https://host/path")
+
+    def test_empty_aliases_no_change(self):
+        aliases = {}
+        manifest = {"key": "@something"}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["key"], "@something")
 
 
 class TestImagesCatalogIntegrity(unittest.TestCase):
@@ -144,6 +180,16 @@ class TestImagesCatalogIntegrity(unittest.TestCase):
         with open(self._CATALOG_PATH) as f:
             return _json.load(f)
 
+    def _all_imgrefs(self, nodes, registry_ctx=""):
+        """Yield every effective imgref in the tree, resolving registry+tag nodes."""
+        for n in nodes:
+            registry = n.get("registry", registry_ctx)
+            if "imgref" in n:
+                yield n["imgref"]
+            elif "tag" in n and registry:
+                yield f"{registry}:{n['tag']}"
+            yield from self._all_imgrefs(n.get("children", []), registry)
+
     def test_no_bare_ampersand_in_names(self):
         """Names must not contain bare & — it breaks Pango markup rendering."""
         catalog = self._load_catalog()
@@ -157,21 +203,59 @@ class TestImagesCatalogIntegrity(unittest.TestCase):
         self.assertEqual(bad, [], f"'Gaming' label found (use Nvidia+CUDA): {bad}")
 
     def test_default_image_present_and_valid(self):
-        """default_image must be set and must exist as a leaf imgref in the tree.
+        """default_image must be set and must exist as a leaf in the tree.
 
-        Without it _DEFAULT_IMAGE is '' and __select_default() never fires,
-        leaving the image step with no selection and breaking the UI and tests.
+        Handles both explicit ``imgref`` leaves and ``registry``+``tag`` shorthand
+        nodes so refactored groups are covered.
         """
         catalog = self._load_catalog()
         default = catalog.get("default_image", "")
         self.assertTrue(default, "default_image is missing or empty in images.json")
 
-        def all_imgrefs(nodes):
-            for n in nodes:
-                if "imgref" in n:
-                    yield n["imgref"]
-                yield from all_imgrefs(n.get("children", []))
-
-        found = list(all_imgrefs(catalog.get("images", [])))
+        found = list(self._all_imgrefs(catalog.get("images", [])))
         self.assertIn(default, found,
                       f"default_image {default!r} is not a leaf imgref in the tree")
+
+    def test_aliases_resolve_without_unknown_refs(self):
+        """Every @alias_name in the catalog must have a corresponding alias definition."""
+        catalog = self._load_catalog()
+        aliases = catalog.get("aliases", {})
+
+        def _collect_alias_refs(obj):
+            if isinstance(obj, dict):
+                for key, val in obj.items():
+                    if key == "aliases":
+                        continue  # skip the definitions dict itself
+                    yield from _collect_alias_refs(val)
+            elif isinstance(obj, list):
+                for item in obj:
+                    yield from _collect_alias_refs(item)
+            elif isinstance(obj, str) and obj.startswith("@"):
+                yield obj[1:]
+
+        unknown = [name for name in _collect_alias_refs(catalog) if name not in aliases]
+        self.assertEqual(unknown, [], f"Unknown alias references in images.json: {unknown}")
+
+    def test_registry_tag_nodes_produce_valid_imgrefs(self):
+        """Every ``tag`` node must have a ``registry`` in scope (itself or ancestor)."""
+        catalog = self._load_catalog()
+
+        def _check(nodes, registry_ctx=""):
+            for n in nodes:
+                registry = n.get("registry", registry_ctx)
+                if "tag" in n and not "imgref" in n:
+                    self.assertTrue(
+                        registry,
+                        f"Node '{n.get('name')}' has 'tag' but no registry in scope"
+                    )
+                    imgref = f"{registry}:{n['tag']}"
+                    self.assertIn(":", imgref,
+                                  f"Composed imgref '{imgref}' missing colon")
+                _check(n.get("children", []), registry)
+
+        _check(catalog.get("images", []))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -66,6 +66,16 @@ class TestAutoDisk:
         r = _load(path)
         assert r["image"] == img
 
+    def test_target_imgref_no_docker_prefix(self):
+        # Regression: targetImgref must be a bare reference, not docker://ghcr.io/...
+        # If docker:// is prepended here, bootc stores it verbatim and subsequent
+        # `bootc update` calls prepend it again → double prefix → broken updates.
+        img = "ghcr.io/projectbluefin/dakota:latest"
+        path = Processor.gen_install_recipe("log", _auto_finals(image=img), _SYS_RECIPE)
+        r = _load(path)
+        assert r["targetImgref"] == img
+        assert not r["targetImgref"].startswith("docker://")
+
     def test_hostname_propagated(self):
         path = Processor.gen_install_recipe("log", _auto_finals(hostname="mybox"), _SYS_RECIPE)
         r = _load(path)


### PR DESCRIPTION
## Summary

Refactors the image catalog parser and `images.json` (via fisherman submodule) for maintainability. All 176 installable images are preserved — zero functional change to what the user can install.

### Parser changes (`bootc_installer/defaults/image.py`)

**`_resolve_aliases()`** — resolves `@alias_name` strings at manifest-load time, before any UI code reads the manifest.

**`registry_ctx` in `__build_node()`** — a `registry` field on any group is inherited by descendants; a leaf with `"tag": "stable"` composes the full imgref as `registry:tag` transparently.

**Collapsed tree by default** — `__selected_imgref` initialised to `None` when `default_image` is absent/empty, so `btn_next` stays disabled until the user picks an image. Distros can set `default_image` in `/etc/bootc-installer/images.json` to restore pre-selection.

### Catalog changes (fisherman submodule → tuna-os/fisherman#7)

- Root `aliases` dict — 4 Brewfile URLs defined once, referenced as `@alias_name`
- All groups migrated to `registry` + `tag` shorthand where applicable
- All `children` arrays alphabetised
- `default_image` removed

### Tests

- `TestResolveAliases` — 6 new unit tests for the alias resolver
- `TestImagesCatalogIntegrity` — `_all_imgrefs()` updated to handle `registry+tag` nodes; two new catalog-level tests (`test_aliases_resolve_without_unknown_refs`, `test_registry_tag_nodes_produce_valid_imgrefs`)
- `test_default_image_present_and_valid` updated — missing `default_image` is now valid