### PR TITLE
feat: support local_imgref for offline live ISO installation

### DIFF
--- a/bootc_installer/utils/processor.py
+++ b/bootc_installer/utils/processor.py
@@ -109,7 +109,8 @@ class Processor:
 
         # --- Image / OCI ref ---
         # In Flatpak mode: finals contain "selected_image" or "custom_image" from the UI.
-        # In live ISO mode: the image step is skipped; recipe["imgref"] holds the local image.
+        # In live ISO mode: the image step is skipped; recipe["imgref"] holds the remote
+        # tracking ref and optional "local_imgref" holds the install source override.
         image = merged.get("custom_image", "") or merged.get("selected_image", "")
         if not image:
             image = sys_recipe.get("imgref", "")
@@ -124,7 +125,21 @@ class Processor:
         if not image:
             logger.warning("No image/imgref found in finals or sys_recipe!")
 
+        # target_imgref is always the remote registry reference written into the
+        # installed system so that bootc upgrade tracks the correct upstream image.
         target_imgref = image
+
+        # local_imgref (live ISO only) is an optional install *source* override — e.g.
+        # "containers-storage:ghcr.io/org/image:tag" for offline installs from a
+        # pre-populated squashfs.  It is passed to fisherman as --source-imgref while
+        # target_imgref (the remote ref) is passed as --target-imgref unchanged.
+        local_imgref = sys_recipe.get("local_imgref", "")
+        if local_imgref:
+            logger.info(
+                f"local_imgref override: install source={local_imgref}, "
+                f"installed system tracks={target_imgref}"
+            )
+            image = local_imgref
 
         # --- Hostname ---
         hostname = merged.get("hostname", sys_recipe.get("hostname", "tunaos"))

--- a/bootc_installer/utils/recipe.py
+++ b/bootc_installer/utils/recipe.py
@@ -58,17 +58,30 @@ class RecipeLoader:
         """Post-load enrichment: detect live ISO mode and inject local bootc image."""
         in_flatpak = os.path.exists("/.flatpak-info")
         is_ostree_booted = os.path.exists("/run/ostree-booted")
-        live_iso_mode = not in_flatpak and is_ostree_booted
+        # Also detect squashfs-based live ISOs (dracut dmsquash-live) which do not
+        # set /run/ostree-booted because they are not ostree deployments.
+        is_live_squashfs = os.path.exists("/run/initramfs/live")
+        live_iso_mode = not in_flatpak and (is_ostree_booted or is_live_squashfs)
 
         if live_iso_mode:
-            imgref = self.__recipe.get("imgref", "") or self.__detect_local_bootc_image()
-            if imgref:
-                logger.info(f"Live ISO mode: using local bootc image {imgref}")
-                self.__recipe["imgref"] = imgref
+            # local_imgref is an optional override for the install *source* used only
+            # in live ISO mode (e.g. "containers-storage:ghcr.io/org/image:tag" for
+            # offline installs from a pre-populated squashfs).  imgref always remains
+            # the remote tracking reference written into the installed system.
+            if not self.__recipe.get("local_imgref"):
+                imgref = self.__recipe.get("imgref", "") or self.__detect_local_bootc_image()
+                if imgref:
+                    logger.info(f"Live ISO mode: using local bootc image {imgref}")
+                    self.__recipe["imgref"] = imgref
+                else:
+                    logger.warning("Live ISO mode: could not detect local bootc image")
             else:
-                logger.warning("Live ISO mode: could not detect local bootc image")
+                logger.info(
+                    f"Live ISO mode: local_imgref override present "
+                    f"({self.__recipe['local_imgref']}), imgref stays as remote tracking ref"
+                )
 
-            # Remove the image selection step — use the local image silently
+            # Remove the image selection step — use the configured image silently
             self.__recipe["steps"].pop("image", None)
             logger.info("Live ISO mode: image selection step removed")
         else:


### PR DESCRIPTION
Fixes #23

## Changes

### `recipe.py` — fix live ISO detection + handle local_imgref

**Live ISO detection**: `/run/ostree-booted` does not exist on squashfs-based live ISOs (dracut dmsquash-live). Add `/run/initramfs/live` as a second indicator so squashfs live environments correctly enter live ISO mode.

**local_imgref handling**: when `local_imgref` is present in the recipe (live ISO mode only), skip the `__detect_local_bootc_image()` fallback and log that the override will be used. `imgref` is left untouched so it remains the remote tracking ref.

### `processor.py` — wire local_imgref → fisherman image field

When `local_imgref` is present in the system recipe, use it as the `image` value (fisherman `--source-imgref`). `target_imgref` continues to use `imgref` (the remote registry ref) so the installed system tracks the correct upstream for upgrades.

Fisherman already supports separate `image` and `targetImgref` fields — no fisherman changes needed.

## Testing

- Squashfs live ISO with `local_imgref` set: install source = containers-storage, target ref = remote registry ref ✓
- Squashfs live ISO without `local_imgref`: existing behaviour unchanged (detect local image via bootc status) ✓
- Flatpak mode: unaffected (`live_iso_mode` stays False) ✓
- Ostree live boot: unaffected (`is_ostree_booted` path unchanged) ✓

## Example recipe.json (Dakota ISO)

```json
{
  "imgref": "ghcr.io/projectbluefin/dakota:latest",
  "local_imgref": "containers-storage:ghcr.io/projectbluefin/dakota:latest",
  "distro_name": "Dakota"
}
```