### PR TITLE
fix: live ISO mode — recipe path, user creation skip, image field fallbacks

### DIFF
--- a/bootc_installer/defaults/user.py
+++ b/bootc_installer/defaults/user.py
@@ -1,9 +1,15 @@
 import re
+import json
 import logging
+import os
 
 from gi.repository import Adw, Gtk
 
 logger = logging.getLogger("Installer::User")
+
+_IN_FLATPAK = os.path.exists("/.flatpak-info")
+_ETC = "/run/host/etc" if _IN_FLATPAK else "/etc"
+_IMAGES_JSON = f"{_ETC}/bootc-installer/images.json"
 
 # Groups added to every created user.
 _DEFAULT_GROUPS = ["wheel"]
@@ -39,8 +45,17 @@ class VanillaDefaultUsers(Adw.Bin):
         """Skip this step unless the selected image requires user creation."""
         image_step = getattr(self.__window, "image_step", None)
         if image_step is None:
-            logger.warning("skip_screen: image_step is None — showing user step by default")
-            return False
+            # Live ISO mode: no image selection step; read needs_user_creation from images.json
+            try:
+                with open(_IMAGES_JSON) as f:
+                    data = json.load(f)
+                images = data.get("images", [data]) if "images" in data else [data]
+                nuc = images[0].get("needs_user_creation", True)
+                logger.info("skip_screen (live ISO): needs_user_creation=%s from images.json → skip=%s", nuc, not nuc)
+                return not nuc
+            except Exception as e:
+                logger.warning("skip_screen: image_step is None and images.json unreadable (%s) — showing user step", e)
+                return False
         nuc = image_step.selected_needs_user_creation
         logger.info("skip_screen: selected_needs_user_creation=%s → skip=%s", nuc, not nuc)
         return not nuc

--- a/bootc_installer/utils/processor.py
+++ b/bootc_installer/utils/processor.py
@@ -156,6 +156,26 @@ class Processor:
         image_filesystem = merged.get("image_filesystem", "") or ""
         flatpak_var_path = merged.get("flatpak_var_path", "") or ""
 
+        # Live ISO mode: image_step is absent so image-level fields are missing
+        # from merged. Fall back to images.json on the host.
+        if not image_filesystem:
+            _in_flatpak = os.path.exists("/.flatpak-info")
+            _etc = "/run/host/etc" if _in_flatpak else "/etc"
+            _images_json = f"{_etc}/bootc-installer/images.json"
+            try:
+                with open(_images_json) as _f:
+                    _idata = json.load(_f)
+                _imgs = _idata.get("images", [_idata]) if "images" in _idata else [_idata]
+                _img = _imgs[0]
+                image_filesystem  = _img.get("filesystem", "") or ""
+                composefs_backend = bool(_img.get("composefs", composefs_backend))
+                bootloader        = _img.get("bootloader", bootloader) or bootloader
+                flatpak_var_path  = _img.get("flatpak_var_path", flatpak_var_path) or flatpak_var_path
+                logger.info("Live ISO fallback from images.json: filesystem=%s composefs=%s bootloader=%s",
+                            image_filesystem, composefs_backend, bootloader)
+            except Exception as _e:
+                logger.warning("Live ISO: could not read %s: %s", _images_json, _e)
+
         # Image-level filesystem requirement overrides the disk-step selection.
         if image_filesystem in ("xfs", "btrfs"):
             filesystem = image_filesystem


### PR DESCRIPTION
## Summary

Fixes three issues when tuna-installer runs on a live ISO:

### 1. Recipe path detection inside Flatpak sandbox (recipe.py)
Inside a Flatpak, `/etc` belongs to the runtime. The host `/etc` is mounted at `/run/host/etc`. Recipe search paths now use the correct prefix, and the `live-iso-mode` flag file check works inside Flatpak.

### 2. User creation step not skipped (user.py)
When live ISO mode removes the image selection step (`image_step = None`), `skip_screen` fell back to showing the user creation form. Now reads `needs_user_creation` from `images.json` as a fallback.

### 3. Filesystem/composefs/bootloader defaults to wrong values (processor.py)
With no image step, `merged` lacks `image_filesystem`, `composefs_backend`, `bootloader`, and `flatpak_var_path`. The installer defaulted to xfs. Now reads these from the first entry in `images.json`.

## Testing
All three fixes were validated by live-patching the installed Flatpak on a running Dakota live ISO VM:
- User creation step correctly skipped ✅
- Recipe generated with btrfs, composefs=true, bootloader=systemd ✅
- Fisherman received correct recipe and proceeded to install ✅

Fixes: #25, #26