### PR TITLE
chore: merge dev into prod — live ISO fixes, fisherman bareImageRef fix, flatpak path fix

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -2,10 +2,10 @@ name: Flatpak
 
 on:
   push:
-    branches: [main, dev]
+    branches: [prod, dev]
     tags: ["v*"]
   pull_request:
-    branches: [main, dev]
+    branches: [prod, dev]
 
 jobs:
   production:
@@ -13,7 +13,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' ||
       startsWith(github.ref, 'refs/tags/') ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/prod'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
@@ -37,14 +37,14 @@ jobs:
           path: org.bootcinstaller.Installer.flatpak
           retention-days: 30
 
-      - name: Publish continuous pre-release (main branch)
-        if: github.ref == 'refs/heads/main'
+      - name: Publish continuous pre-release (prod branch)
+        if: github.ref == 'refs/heads/prod'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: continuous
           name: Continuous Build
           prerelease: true
-          body: "Latest build from the `main` branch. Updated automatically on every push."
+          body: "Latest build from the `prod` branch. Updated automatically on every push."
           files: org.bootcinstaller.Installer.flatpak
 
       - name: Attach bundle to tagged release

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, dev]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   production:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,9 +2,9 @@ name: Go Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [prod, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [prod, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,9 +2,9 @@ name: Go Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, dev]
+        branch: [prod, dev]
     name: "Go Tests (${{ matrix.branch }})"
     runs-on: ubuntu-latest
 
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, dev]
+        branch: [prod, dev]
     name: "Python Unit Tests (${{ matrix.branch }})"
     runs-on: ubuntu-latest
 
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, dev]
+        branch: [prod, dev]
     name: "Python UI Tests (${{ matrix.branch }})"
     runs-on: ubuntu-latest
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,110 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # 06:00 UTC daily
+  workflow_dispatch:
+
+jobs:
+  go-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, dev]
+    name: "Go Tests (${{ matrix.branch }})"
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: fisherman/fisherman
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          submodules: recursive
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+          cache-dependency-path: fisherman/fisherman/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test -v -count=1 -timeout=60s ./...
+
+      - name: Run tests with race detector
+        run: go test -race -count=1 -timeout=60s ./...
+
+  python-unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, dev]
+    name: "Python Unit Tests (${{ matrix.branch }})"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install pytest
+
+      - run: pytest tests/unit/ -v --tb=short
+
+  python-ui:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, dev]
+    name: "Python UI Tests (${{ matrix.branch }})"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            python3-pytest \
+            python3-gi \
+            python3-gi-cairo \
+            gir1.2-gtk-4.0 \
+            gir1.2-adw-1 \
+            gir1.2-vte-3.91 \
+            blueprint-compiler \
+            meson \
+            ninja-build \
+            libglib2.0-dev \
+            desktop-file-utils \
+            appstream \
+            gettext \
+            xvfb
+
+      - name: Build GResources
+        run: |
+          meson setup build \
+            -Dbuild-fisherman=false \
+            --prefix=/tmp/tuna-install
+          ninja -C build
+          RESOURCE=$(find build -name "bootc-installer.gresource" | head -1)
+          echo "TUNA_RESOURCE=${RESOURCE}" >> $GITHUB_ENV
+
+      - name: Run UI integration tests (Xvfb)
+        env:
+          GTK_A11Y: none
+          NO_AT_BRIDGE: "1"
+        run: xvfb-run -a python3 -m pytest tests/ui/ -v --tb=short -p no:cacheprovider

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,9 +2,9 @@ name: Python Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [prod, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [prod, dev]
   workflow_dispatch:
 
 jobs:

--- a/bootc_installer/defaults/image.py
+++ b/bootc_installer/defaults/image.py
@@ -98,7 +98,45 @@ def _load_manifest():
         return {"fallback_flatpaks": [], "images": []}
 
 
+def _resolve_aliases(obj: object, aliases: dict) -> None:
+    """Recursively replace ``@alias_name`` strings with values from *aliases*.
+
+    Any string value (in a dict or list) that starts with ``@`` is treated as
+    an alias reference.  Unknown aliases are left as-is so the parser can
+    surface a meaningful error later rather than silently corrupting data.
+
+    This runs once at manifest-load time so the rest of the codebase never
+    needs to know about the alias syntax.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, str) and value.startswith("@"):
+                resolved = aliases.get(value[1:])
+                if resolved is not None:
+                    obj[key] = resolved
+                else:
+                    logger.warning(f"images.json: unknown alias '{value}'")
+            else:
+                _resolve_aliases(value, aliases)
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            if isinstance(value, str) and value.startswith("@"):
+                resolved = aliases.get(value[1:])
+                if resolved is not None:
+                    obj[i] = resolved
+                else:
+                    logger.warning(f"images.json: unknown alias '{value}'")
+            else:
+                _resolve_aliases(value, aliases)
+
+
 _MANIFEST = _load_manifest()
+
+# Resolve @alias references before anything else reads the manifest.
+_aliases = _MANIFEST.get("aliases", {})
+if _aliases:
+    _resolve_aliases(_MANIFEST, _aliases)
+
 _IMAGE_TREE = _MANIFEST["images"]
 _DEFAULT_IMAGE = _MANIFEST.get("default_image", "")
 _FALLBACK_FLATPAKS = _MANIFEST["fallback_flatpaks"]
@@ -296,9 +334,9 @@ class VanillaDefaultImage(Adw.Bin):
                     img.get("description", ""), "", [exp])
             self.list_images.append(exp)
 
-    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx=""):
+    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx="", registry_ctx=""):
         """Recursively build ExpanderRow groups and ActionRow leaves."""
-        # Inherit flatpaks, icon, carousel, needs_user_creation, composefs, image_type, bootloader, image_filesystem, and flatpak_var_path from nearest ancestor.
+        # Inherit flatpaks, icon, carousel, needs_user_creation, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, and registry from nearest ancestor.
         node_flatpaks = node.get("flatpaks", flatpaks_ctx)
         node_icon = node.get("icon", icon_ctx)
         node_carousel = node.get("carousel", carousel_ctx)
@@ -308,9 +346,23 @@ class VanillaDefaultImage(Adw.Bin):
         node_bootloader = node.get("bootloader", bootloader_ctx)
         node_image_filesystem = node.get("filesystem", image_filesystem_ctx)
         node_flatpak_var_path = node.get("flatpak_var_path", flatpak_var_path_ctx)
+        node_registry = node.get("registry", registry_ctx)
 
-        if "imgref" in node:
-            self.__add_leaf(parent, node["name"], node["imgref"],
+        # A leaf can use "tag" instead of a full "imgref" when a "registry" is
+        # available from this node or an ancestor.  The full imgref is composed
+        # as "registry:tag" so the rest of the code never sees the shorthand.
+        imgref = node.get("imgref")
+        if imgref is None and "tag" in node:
+            if node_registry:
+                imgref = f"{node_registry}:{node['tag']}"
+            else:
+                logger.warning(
+                    f"images.json: node '{node.get('name')}' has 'tag' but no "
+                    f"'registry' in scope — skipping leaf"
+                )
+
+        if imgref is not None:
+            self.__add_leaf(parent, node["name"], imgref,
                             node.get("desc", ""), search_ctx, ancestors,
                             node_flatpaks, node_icon, node_carousel, node_needs_user,
                             node_composefs, node_image_type, node_bootloader, node_image_filesystem,
@@ -336,7 +388,7 @@ class VanillaDefaultImage(Adw.Bin):
         child_ancestors = ancestors + [exp]
 
         for child in node.get("children", []):
-            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path)
+            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path, node_registry)
 
         if parent is self.list_images:
             parent.append(exp)

--- a/bootc_installer/defaults/image.py
+++ b/bootc_installer/defaults/image.py
@@ -280,7 +280,7 @@ class VanillaDefaultImage(Adw.Bin):
         self.__step = step
         self.delta = False
 
-        self.__selected_imgref = _DEFAULT_IMAGE
+        self.__selected_imgref = _DEFAULT_IMAGE or None
         self.__selected_flatpaks = None  # per-image flatpak list (None = use fallback)
         self.__selected_flatpak_var_path = ""  # override for writable var path (e.g. GnomeOS)
         self.__selected_carousel = None  # per-image carousel slides (None = use recipe default)

--- a/bootc_installer/defaults/user.py
+++ b/bootc_installer/defaults/user.py
@@ -1,9 +1,15 @@
 import re
+import json
 import logging
+import os
 
 from gi.repository import Adw, Gtk
 
 logger = logging.getLogger("Installer::User")
+
+_IN_FLATPAK = os.path.exists("/.flatpak-info")
+_ETC = "/run/host/etc" if _IN_FLATPAK else "/etc"
+_IMAGES_JSON = f"{_ETC}/bootc-installer/images.json"
 
 # Groups added to every created user.
 _DEFAULT_GROUPS = ["wheel"]
@@ -39,8 +45,17 @@ class VanillaDefaultUsers(Adw.Bin):
         """Skip this step unless the selected image requires user creation."""
         image_step = getattr(self.__window, "image_step", None)
         if image_step is None:
-            logger.warning("skip_screen: image_step is None — showing user step by default")
-            return False
+            # Live ISO mode: no image selection step; read needs_user_creation from images.json
+            try:
+                with open(_IMAGES_JSON) as f:
+                    data = json.load(f)
+                images = data.get("images", [data]) if "images" in data else [data]
+                nuc = images[0].get("needs_user_creation", True)
+                logger.info("skip_screen (live ISO): needs_user_creation=%s from images.json → skip=%s", nuc, not nuc)
+                return not nuc
+            except Exception as e:
+                logger.warning("skip_screen: image_step is None and images.json unreadable (%s) — showing user step", e)
+                return False
         nuc = image_step.selected_needs_user_creation
         logger.info("skip_screen: selected_needs_user_creation=%s → skip=%s", nuc, not nuc)
         return not nuc

--- a/bootc_installer/utils/processor.py
+++ b/bootc_installer/utils/processor.py
@@ -156,6 +156,26 @@ class Processor:
         image_filesystem = merged.get("image_filesystem", "") or ""
         flatpak_var_path = merged.get("flatpak_var_path", "") or ""
 
+        # Live ISO mode: image_step is absent so image-level fields are missing
+        # from merged. Fall back to images.json on the host.
+        if not image_filesystem:
+            _in_flatpak = os.path.exists("/.flatpak-info")
+            _etc = "/run/host/etc" if _in_flatpak else "/etc"
+            _images_json = f"{_etc}/bootc-installer/images.json"
+            try:
+                with open(_images_json) as _f:
+                    _idata = json.load(_f)
+                _imgs = _idata.get("images", [_idata]) if "images" in _idata else [_idata]
+                _img = _imgs[0]
+                image_filesystem  = _img.get("filesystem", "") or ""
+                composefs_backend = bool(_img.get("composefs", composefs_backend))
+                bootloader        = _img.get("bootloader", bootloader) or bootloader
+                flatpak_var_path  = _img.get("flatpak_var_path", flatpak_var_path) or flatpak_var_path
+                logger.info("Live ISO fallback from images.json: filesystem=%s composefs=%s bootloader=%s",
+                            image_filesystem, composefs_backend, bootloader)
+            except Exception as _e:
+                logger.warning("Live ISO: could not read %s: %s", _images_json, _e)
+
         # Image-level filesystem requirement overrides the disk-step selection.
         if image_filesystem in ("xfs", "btrfs"):
             filesystem = image_filesystem

--- a/bootc_installer/utils/processor.py
+++ b/bootc_installer/utils/processor.py
@@ -109,7 +109,8 @@ class Processor:
 
         # --- Image / OCI ref ---
         # In Flatpak mode: finals contain "selected_image" or "custom_image" from the UI.
-        # In live ISO mode: the image step is skipped; recipe["imgref"] holds the local image.
+        # In live ISO mode: the image step is skipped; recipe["imgref"] holds the remote
+        # tracking ref and optional "local_imgref" holds the install source override.
         image = merged.get("custom_image", "") or merged.get("selected_image", "")
         if not image:
             image = sys_recipe.get("imgref", "")
@@ -124,7 +125,21 @@ class Processor:
         if not image:
             logger.warning("No image/imgref found in finals or sys_recipe!")
 
+        # target_imgref is always the remote registry reference written into the
+        # installed system so that bootc upgrade tracks the correct upstream image.
         target_imgref = image
+
+        # local_imgref (live ISO only) is an optional install *source* override — e.g.
+        # "containers-storage:ghcr.io/org/image:tag" for offline installs from a
+        # pre-populated squashfs.  It is passed to fisherman as --source-imgref while
+        # target_imgref (the remote ref) is passed as --target-imgref unchanged.
+        local_imgref = sys_recipe.get("local_imgref", "")
+        if local_imgref:
+            logger.info(
+                f"local_imgref override: install source={local_imgref}, "
+                f"installed system tracks={target_imgref}"
+            )
+            image = local_imgref
 
         # --- Hostname ---
         hostname = merged.get("hostname", sys_recipe.get("hostname", "tunaos"))

--- a/bootc_installer/utils/recipe.py
+++ b/bootc_installer/utils/recipe.py
@@ -25,12 +25,22 @@ logger = logging.getLogger("Installer::RecipeLoader")
 
 
 class RecipeLoader:
-    recipe_paths = [
-        "/etc/bootc-installer/recipe.json",
-        "/etc/tunaos-installer/recipe.json",
-        "/etc/vanilla-installer/recipe.json",
-        "/app/share/bootc-installer/recipe.json",
-    ]
+    # When running inside a Flatpak sandbox, /etc is reserved by the runtime
+    # and inaccessible at /etc/.  The host filesystem /etc is available at
+    # /run/host/etc instead.  We detect this at class instantiation time and
+    # prefix all /etc/ recipe search paths accordingly.
+    _in_flatpak: bool = os.path.exists("/.flatpak-info")
+    _etc: str = "/run/host/etc" if os.path.exists("/.flatpak-info") else "/etc"
+
+    @property
+    def recipe_paths(self):
+        return [
+            f"{self._etc}/bootc-installer/recipe.json",
+            f"{self._etc}/tunaos-installer/recipe.json",
+            f"{self._etc}/vanilla-installer/recipe.json",
+            "/app/share/bootc-installer/recipe.json",
+        ]
+
     recipe_path = None
 
     def __init__(self):
@@ -38,10 +48,13 @@ class RecipeLoader:
         self.__load()
 
     def __load(self):
-        if "VANILLA_CUSTOM_RECIPE" in os.environ:
-            self.recipe_paths = [os.environ["VANILLA_CUSTOM_RECIPE"]]
+        paths = (
+            [os.environ["VANILLA_CUSTOM_RECIPE"]]
+            if "VANILLA_CUSTOM_RECIPE" in os.environ
+            else self.recipe_paths
+        )
 
-        for path in self.recipe_paths:
+        for path in paths:
             if os.path.exists(path):
                 self.recipe_path = path
                 with open(path, "r") as f:
@@ -51,17 +64,21 @@ class RecipeLoader:
                     return
                 logger.warning(f"Recipe at {path} failed validation, trying next...")
 
-        logger.error(f"No valid recipe found. Tried: {self.recipe_paths}")
+        logger.error(f"No valid recipe found. Tried: {paths}")
         sys.exit(1)
 
     def __enrich(self):
         """Post-load enrichment: detect live ISO mode and inject local bootc image."""
-        in_flatpak = os.path.exists("/.flatpak-info")
         is_ostree_booted = os.path.exists("/run/ostree-booted")
         # Also detect squashfs-based live ISOs (dracut dmsquash-live) which do not
         # set /run/ostree-booted because they are not ostree deployments.
         is_live_squashfs = os.path.exists("/run/initramfs/live")
-        live_iso_mode = not in_flatpak and (is_ostree_booted or is_live_squashfs)
+        # A live ISO builder can drop a flag file at /etc/bootc-installer/live-iso-mode
+        # to explicitly activate live ISO mode.  This is the only reliable signal when
+        # the installer runs inside a Flatpak sandbox (where /.flatpak-info exists and
+        # /run/initramfs/live or /run/ostree-booted may be inaccessible).
+        is_live_flagged = os.path.exists(f"{self._etc}/bootc-installer/live-iso-mode")
+        live_iso_mode = is_live_flagged or (not self._in_flatpak and (is_ostree_booted or is_live_squashfs))
 
         if live_iso_mode:
             # local_imgref is an optional override for the install *source* used only

--- a/bootc_installer/utils/recipe.py
+++ b/bootc_installer/utils/recipe.py
@@ -58,17 +58,30 @@ class RecipeLoader:
         """Post-load enrichment: detect live ISO mode and inject local bootc image."""
         in_flatpak = os.path.exists("/.flatpak-info")
         is_ostree_booted = os.path.exists("/run/ostree-booted")
-        live_iso_mode = not in_flatpak and is_ostree_booted
+        # Also detect squashfs-based live ISOs (dracut dmsquash-live) which do not
+        # set /run/ostree-booted because they are not ostree deployments.
+        is_live_squashfs = os.path.exists("/run/initramfs/live")
+        live_iso_mode = not in_flatpak and (is_ostree_booted or is_live_squashfs)
 
         if live_iso_mode:
-            imgref = self.__recipe.get("imgref", "") or self.__detect_local_bootc_image()
-            if imgref:
-                logger.info(f"Live ISO mode: using local bootc image {imgref}")
-                self.__recipe["imgref"] = imgref
+            # local_imgref is an optional override for the install *source* used only
+            # in live ISO mode (e.g. "containers-storage:ghcr.io/org/image:tag" for
+            # offline installs from a pre-populated squashfs).  imgref always remains
+            # the remote tracking reference written into the installed system.
+            if not self.__recipe.get("local_imgref"):
+                imgref = self.__recipe.get("imgref", "") or self.__detect_local_bootc_image()
+                if imgref:
+                    logger.info(f"Live ISO mode: using local bootc image {imgref}")
+                    self.__recipe["imgref"] = imgref
+                else:
+                    logger.warning("Live ISO mode: could not detect local bootc image")
             else:
-                logger.warning("Live ISO mode: could not detect local bootc image")
+                logger.info(
+                    f"Live ISO mode: local_imgref override present "
+                    f"({self.__recipe['local_imgref']}), imgref stays as remote tracking ref"
+                )
 
-            # Remove the image selection step — use the local image silently
+            # Remove the image selection step — use the configured image silently
             self.__recipe["steps"].pop("image", None)
             logger.info("Live ISO mode: image selection step removed")
         else:

--- a/docs/live-iso.md
+++ b/docs/live-iso.md
@@ -1,0 +1,351 @@
+# Building a bootc Live ISO with tuna-installer
+
+This document explains how to build a bootable live ISO that auto-launches
+tuna-installer for offline installation of a bootc image. It documents the
+configuration conventions the installer expects, and the OS-image-side setup
+needed to make everything work end-to-end.
+
+The reference implementation is [tuna-os/dakota-iso](https://github.com/tuna-os/dakota-iso).
+
+---
+
+## Overview
+
+A live ISO built for tuna-installer must:
+
+1. Embed the target OCI image in the squashfs (as VFS containers-storage).
+2. Auto-start the installer Flatpak as the live user.
+3. Configure the installer via `/etc/bootc-installer/` so it skips steps that
+   are only meaningful during a normal (non-live) install (user creation, image
+   selection).
+4. Set up polkit so the live user can run fisherman without a password prompt.
+5. Redirect write-heavy scratch paths to the target disk to work around the
+   size-limited live overlay.
+
+---
+
+## Installer configuration files
+
+All files live in `/etc/bootc-installer/` on the live squashfs.
+
+### `live-iso-mode` flag file
+
+```
+/etc/bootc-installer/live-iso-mode
+```
+
+An **empty file**. Its presence tells the installer it is running on a live ISO
+and activates offline install mode. When running inside a Flatpak sandbox the
+installer looks for this file at `/run/host/etc/bootc-installer/live-iso-mode`.
+
+### `images.json`
+
+Locks the installer to a specific image and provides image-specific defaults so
+the user is not asked questions the ISO already knows the answers to.
+
+```json
+{
+  "default_image": "ghcr.io/your-org/your-image:latest",
+  "fallback_flatpaks": [],
+  "images": [
+    {
+      "name": "My OS",
+      "imgref": "ghcr.io/your-org/your-image:latest",
+      "desc": "Brief description shown in the installer",
+      "icon": "resource:///org/bootcinstaller/Installer/images/my-os.png",
+      "bootloader": "systemd",
+      "filesystem": "btrfs",
+      "composefs": true,
+      "needs_user_creation": false,
+      "flatpak_var_path": "state/os/default/var"
+    }
+  ]
+}
+```
+
+Key fields:
+
+| Field | Purpose |
+|---|---|
+| `bootloader` | `"systemd"` or `"grub2"` — passed to fisherman's recipe |
+| `filesystem` | `"btrfs"` or `"xfs"` |
+| `composefs` | `true` for composefs-native images (GNOME OS, Project Bluefin/Dakota) |
+| `needs_user_creation` | `false` on a live ISO — skips the user creation screen |
+| `flatpak_var_path` | Relative path to writable `/var` inside the installed target. For composefs-native images: `"state/os/default/var"` |
+
+When `needs_user_creation` is `false`, the installer skips the user creation
+screen entirely. The installed system's first-boot experience (e.g. GNOME
+initial-setup) handles account creation.
+
+### `recipe.json`
+
+Provides branding (distro name, tour slides) and the default install recipe
+sent to fisherman.
+
+```json
+{
+  "distro_name": "My OS",
+  "distro_version": "latest",
+  "tour_slides": [],
+  "steps": []
+}
+```
+
+Refer to the tuna-installer source for the full schema.
+
+---
+
+## Autostart `.desktop` entry
+
+The installer must be started automatically when the live user logs in via GDM.
+Place a `.desktop` file in `/etc/xdg/autostart/`:
+
+```ini
+[Desktop Entry]
+Name=My OS Installer
+Exec=flatpak run --env=VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json org.bootcinstaller.Installer
+Icon=/usr/share/pixmaps/my-os.png
+Type=Application
+X-GNOME-Autostart-enabled=true
+```
+
+**Important:** pass `VANILLA_CUSTOM_RECIPE` at the `/run/host/etc/...` path.
+Inside the Flatpak sandbox, the host `/etc` is bind-mounted at `/run/host/etc`;
+the installer's recipe loader uses this prefix automatically when the
+`live-iso-mode` flag is present.
+
+For the development channel build (`org.bootcinstaller.Installer.Devel`) use
+the Devel app ID instead.
+
+---
+
+## Polkit setup
+
+fisherman runs via `pkexec` and requires polkit approval for the
+`org.tunaos.Installer.install` action. On a live ISO, liveuser must be allowed
+to trigger this without a password.
+
+### 1. Create the action policy
+
+Write the polkit action definition directly so it is not dependent on the
+Flatpak being installed at build time:
+
+```xml
+<!-- /usr/share/polkit-1/actions/org.bootcinstaller.Installer.policy -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <action id="org.tunaos.Installer.install">
+    <description>Install an operating system to disk</description>
+    <message>Authentication is required to install an operating system</message>
+    <icon_name>drive-harddisk</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/local/bin/fisherman</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+</policyconfig>
+```
+
+### 2. Symlink fisherman to `/usr/local/bin`
+
+The polkit action's `exec.path` annotation points to `/usr/local/bin/fisherman`.
+Create this symlink after the installer Flatpak is pre-installed on the squashfs:
+
+```bash
+INSTALLER_APP_DIR=$(find /var/lib/flatpak/app/org.bootcinstaller.Installer \
+    -name fisherman -type f 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+ln -sf "${INSTALLER_APP_DIR}/fisherman" /usr/local/bin/fisherman
+```
+
+### 3. JS rules fallback
+
+A belt-and-suspenders JS rule handles edge cases where logind has not yet
+marked the session active (e.g. GDM autologin):
+
+```javascript
+// /etc/polkit-1/rules.d/99-live-installer.rules
+polkit.addRule(function(action, subject) {
+    if (action.id === "org.tunaos.Installer.install" &&
+            subject.user === "liveuser" && subject.local) {
+        return polkit.Result.YES;
+    }
+});
+```
+
+---
+
+## VFS containers-storage
+
+The target OCI image must be pre-pulled into the squashfs as VFS
+containers-storage at `/var/lib/containers/storage`. fisherman detects an
+offline install when `CheckImage` finds the image locally and the registry is
+unreachable.
+
+Configure podman to use the VFS driver so it finds the pre-embedded image:
+
+```toml
+# /etc/containers/storage.conf
+[storage]
+driver = "vfs"
+runroot = "/run/containers/storage"
+graphroot = "/var/lib/containers/storage"
+```
+
+Without this, podman initialises with the overlay driver at first boot and
+creates a `db.sql` that conflicts with VFS access.
+
+---
+
+## Disk space: redirecting scratch to the target disk
+
+The live rootfs overlay is typically only 1–2 GiB. fisherman's offline install
+path needs roughly 20 GiB of scratch space across three operations:
+
+| Operation | Writes to | Size |
+|---|---|---|
+| `skopeo copy` temp files (`container_images_*`) | `/var/tmp` | ~8 GiB |
+| OCI cache output | `/var/fisherman-tmp` | ~3.5 GiB |
+| bootc VFS layer writes | `/var/lib/containers/storage` | ~8 GiB |
+
+The solution is to redirect all of these to a btrfs `@scratch` subvolume
+created on the target disk, which fisherman has already partitioned and mounted
+by the time skopeo runs.
+
+### How it works
+
+Wrap `/usr/bin/skopeo` with a shell script that, immediately before delegating
+to the real `skopeo`, creates a `@scratch` btrfs subvolume on the target disk
+and sets up the following mounts:
+
+```
+@scratch/var-tmp   →  bind mount over /var/tmp          (skopeo temp files)
+@scratch/var-tmp   →  bind mount over /var/fisherman-tmp (OCI cache)
+@scratch/cs-upper  →  overlay upperdir over /var/lib/containers/storage
+                       (lowerdir = squashfs VFS storage, read-only)
+```
+
+Mounting `@scratch` as a mount point on the target satisfies bootc's
+*"Verifying empty rootfs: Requiring directory contains only mount points"*
+check — mount points are explicitly permitted.
+
+```bash
+#!/bin/bash
+# /usr/bin/skopeo  (wrapper — real binary at /usr/bin/skopeo.real)
+
+# Strip double transport prefix (fisherman bug workaround — fixed upstream)
+ARGS=()
+for arg in "$@"; do
+    ARGS+=("${arg/containers-storage:containers-storage:/containers-storage:}")
+done
+
+for target in /mnt/fisherman-target /var/mnt/fisherman-target; do
+    if mountpoint -q "$target" 2>/dev/null; then
+        SCRATCH="$target/@scratch"
+        [ -d "$SCRATCH" ] || btrfs subvolume create "$SCRATCH"
+        DEV=$(findmnt -n -o SOURCE "$target" | head -1)
+        mount -o subvol=@scratch "$DEV" "$SCRATCH"
+
+        mkdir -p "$SCRATCH/var-tmp"
+        mount --bind "$SCRATCH/var-tmp" /var/tmp
+        [ -d /var/fisherman-tmp ] && mount --bind "$SCRATCH/var-tmp" /var/fisherman-tmp
+
+        CS=/var/lib/containers/storage
+        LOWER=/run/rootfsbase/var/lib/containers/storage
+        if [ -d "$LOWER" ] && ! mountpoint -q "$CS" 2>/dev/null; then
+            mkdir -p "$SCRATCH/cs-upper" "$SCRATCH/cs-work"
+            mount -t overlay overlay \
+                -o "lowerdir=$LOWER,upperdir=$SCRATCH/cs-upper,workdir=$SCRATCH/cs-work" \
+                "$CS"
+        fi
+        break
+    fi
+done
+exec /usr/bin/skopeo.real "${ARGS[@]}"
+```
+
+Also wrap `/usr/bin/podman` as a pass-through so that fisherman's cleanup code
+cannot accidentally unmount `/var/tmp` and break mount propagation to
+`/var/fisherman-tmp`:
+
+```bash
+#!/bin/bash
+# /usr/bin/podman  (wrapper — real binary at /usr/bin/podman.real)
+exec /usr/bin/podman.real "$@"
+```
+
+> **Why the podman wrapper matters:** fisherman bind-mounts `/var/fisherman-tmp`
+> onto `/var/tmp`, then the skopeo wrapper bind-mounts `@scratch/var-tmp` onto
+> `/var/tmp`. Due to mount propagation, `/var/fisherman-tmp` now also points to
+> `@scratch`. If the podman wrapper were to unmount `/var/tmp` after the OCI
+> export, that propagated mount would be removed, making the OCI cache invisible
+> to bootc inside the podman container. The pass-through wrapper prevents this.
+
+### Memory: don't use a tmpfs upperdir
+
+Using a tmpfs as the overlay upperdir for `/var/lib/containers/storage` is
+tempting but will OOM the guest — the VFS storage is 8+ GiB and a tmpfs
+consumes guest RAM. Always use a real disk (the target btrfs partition) as the
+upperdir.
+
+---
+
+## Lock screen disable
+
+On a live ISO the screen should never lock (the user has not set a password and
+a locked screen is unrecoverable). Lock dconf keys:
+
+```bash
+mkdir -p /etc/dconf/db/local.d /etc/dconf/db/local.d/locks
+
+cat > /etc/dconf/db/local.d/00-live-iso << 'EOF'
+[org/gnome/desktop/screensaver]
+lock-enabled=false
+idle-activation-enabled=false
+
+[org/gnome/desktop/session]
+idle-delay=uint32 0
+EOF
+
+cat > /etc/dconf/db/local.d/locks/live-iso << 'EOF'
+/org/gnome/desktop/screensaver/lock-enabled
+/org/gnome/desktop/screensaver/idle-activation-enabled
+/org/gnome/desktop/session/idle-delay
+EOF
+
+dconf update
+```
+
+---
+
+## GDM autologin
+
+```ini
+# /etc/gdm/custom.conf
+[daemon]
+AutomaticLoginEnable=True
+AutomaticLogin=liveuser
+```
+
+---
+
+## Summary checklist
+
+- [ ] `/etc/bootc-installer/live-iso-mode` (empty flag file)
+- [ ] `/etc/bootc-installer/images.json` with `needs_user_creation: false` and correct `bootloader`/`filesystem`/`composefs`/`flatpak_var_path`
+- [ ] `/etc/bootc-installer/recipe.json` with distro branding
+- [ ] `/etc/xdg/autostart/tuna-installer.desktop` with `VANILLA_CUSTOM_RECIPE=/run/host/etc/...`
+- [ ] `/usr/share/polkit-1/actions/org.bootcinstaller.Installer.policy` with `allow_active=yes`
+- [ ] `/etc/polkit-1/rules.d/99-live-installer.rules` JS fallback
+- [ ] `/usr/local/bin/fisherman` symlink into Flatpak bundle
+- [ ] `/etc/containers/storage.conf` with `driver = "vfs"`
+- [ ] `/usr/bin/skopeo` wrapper redirecting scratch to target `@scratch` btrfs subvolume
+- [ ] `/usr/bin/podman` pass-through wrapper
+- [ ] `/var/fisherman-tmp` pre-created directory
+- [ ] dconf lock-screen keys disabled
+- [ ] GDM autologin configured for `liveuser`

--- a/docs/live-iso.md
+++ b/docs/live-iso.md
@@ -121,14 +121,26 @@ the Devel app ID instead.
 
 ## Polkit setup
 
-fisherman runs via `pkexec` and requires polkit approval for the
-`org.tunaos.Installer.install` action. On a live ISO, liveuser must be allowed
-to trigger this without a password.
+fisherman runs via `pkexec` and requires polkit approval. On a live ISO,
+liveuser must be allowed to trigger this without a password.
 
-### 1. Create the action policy
+### The exec action ID issue
 
-Write the polkit action definition directly so it is not dependent on the
-Flatpak being installed at build time:
+tuna-installer copies the fisherman binary from the Flatpak bundle to a
+**temporary path** (e.g. `/var/home/liveuser/.cache/bootc-installer/fisherman`)
+and calls `pkexec` on that path. Because the path does not match any
+`org.freedesktop.policykit.exec.path` annotation, polkit fires the generic
+**`org.freedesktop.policykit.exec`** action instead of
+`org.tunaos.Installer.install`.
+
+The custom polkit action definition (with `exec.path=/usr/local/bin/fisherman`)
+therefore **never fires** in practice. The JS rules approach below is what
+actually grants passwordless execution.
+
+### 1. Create the action policy (for completeness)
+
+Write the polkit action definition so it is not dependent on the Flatpak being
+installed at build time:
 
 ```xml
 <!-- /usr/share/polkit-1/actions/org.bootcinstaller.Installer.policy -->
@@ -152,30 +164,33 @@ Flatpak being installed at build time:
 </policyconfig>
 ```
 
-### 2. Symlink fisherman to `/usr/local/bin`
+### 2. JS rules — the effective grant
 
-The polkit action's `exec.path` annotation points to `/usr/local/bin/fisherman`.
-Create this symlink after the installer Flatpak is pre-installed on the squashfs:
+A JS rule is required to cover both `org.tunaos.Installer.install` **and**
+`org.freedesktop.policykit.exec` (the action actually fired when pkexec is
+called on the temp fisherman path):
+
+```javascript
+// /etc/polkit-1/rules.d/99-live-installer.rules
+polkit.addRule(function(action, subject) {
+    if ((action.id === "org.tunaos.Installer.install" ||
+         action.id === "org.freedesktop.policykit.exec") &&
+            subject.user === "liveuser" && subject.local) {
+        return polkit.Result.YES;
+    }
+});
+```
+
+> **Security note:** Granting `org.freedesktop.policykit.exec` to liveuser is
+> safe on a live ISO — liveuser already has passwordless sudo in the live
+> session, and the session is ephemeral and single-purpose.
+
+### 3. Symlink fisherman to `/usr/local/bin`
 
 ```bash
 INSTALLER_APP_DIR=$(find /var/lib/flatpak/app/org.bootcinstaller.Installer \
     -name fisherman -type f 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
 ln -sf "${INSTALLER_APP_DIR}/fisherman" /usr/local/bin/fisherman
-```
-
-### 3. JS rules fallback
-
-A belt-and-suspenders JS rule handles edge cases where logind has not yet
-marked the session active (e.g. GDM autologin):
-
-```javascript
-// /etc/polkit-1/rules.d/99-live-installer.rules
-polkit.addRule(function(action, subject) {
-    if (action.id === "org.tunaos.Installer.install" &&
-            subject.user === "liveuser" && subject.local) {
-        return polkit.Result.YES;
-    }
-});
 ```
 
 ---
@@ -295,30 +310,52 @@ upperdir.
 
 ---
 
-## Lock screen disable
+## Lock screen and sleep disable
 
 On a live ISO the screen should never lock (the user has not set a password and
-a locked screen is unrecoverable). Lock dconf keys:
+a locked screen is unrecoverable). Also disable sleep/suspend so a long install
+is not interrupted.
+
+**Important:** Check which system-db name your base image's dconf profile uses.
+Project Bluefin / Dakota uses `system-db:distro`, so overrides must go in
+`/etc/dconf/db/distro.d/`. Writing to `local.d/` will be silently ignored if
+the profile does not reference `system-db:local`. Do **not** overwrite the
+profile file — that would lose the base image's own dconf settings.
 
 ```bash
-mkdir -p /etc/dconf/db/local.d /etc/dconf/db/local.d/locks
+# Check the base image profile to find the right db name:
+#   cat /etc/dconf/profile/user  → look for "system-db:XXX"
+DB_NAME=distro   # or "local" depending on your base image
 
-cat > /etc/dconf/db/local.d/00-live-iso << 'EOF'
+mkdir -p /etc/dconf/db/${DB_NAME}.d /etc/dconf/db/${DB_NAME}.d/locks
+
+cat > /etc/dconf/db/${DB_NAME}.d/50-live-iso << 'EOF'
 [org/gnome/desktop/screensaver]
 lock-enabled=false
 idle-activation-enabled=false
 
 [org/gnome/desktop/session]
 idle-delay=uint32 0
+
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
+sleep-inactive-ac-timeout=0
+sleep-inactive-battery-timeout=0
 EOF
 
-cat > /etc/dconf/db/local.d/locks/live-iso << 'EOF'
+cat > /etc/dconf/db/${DB_NAME}.d/locks/live-iso << 'EOF'
 /org/gnome/desktop/screensaver/lock-enabled
 /org/gnome/desktop/screensaver/idle-activation-enabled
 /org/gnome/desktop/session/idle-delay
+/org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-type
+/org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-type
 EOF
 
 dconf update
+
+# Also mask systemd sleep targets as belt-and-suspenders
+systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
 ```
 
 ---
@@ -340,12 +377,14 @@ AutomaticLogin=liveuser
 - [ ] `/etc/bootc-installer/images.json` with `needs_user_creation: false` and correct `bootloader`/`filesystem`/`composefs`/`flatpak_var_path`
 - [ ] `/etc/bootc-installer/recipe.json` with distro branding
 - [ ] `/etc/xdg/autostart/tuna-installer.desktop` with `VANILLA_CUSTOM_RECIPE=/run/host/etc/...`
-- [ ] `/usr/share/polkit-1/actions/org.bootcinstaller.Installer.policy` with `allow_active=yes`
-- [ ] `/etc/polkit-1/rules.d/99-live-installer.rules` JS fallback
+- [ ] `/usr/share/polkit-1/actions/org.bootcinstaller.Installer.policy`
+- [ ] `/etc/polkit-1/rules.d/99-live-installer.rules` JS rule covering **both** `org.tunaos.Installer.install` and `org.freedesktop.policykit.exec`
 - [ ] `/usr/local/bin/fisherman` symlink into Flatpak bundle
 - [ ] `/etc/containers/storage.conf` with `driver = "vfs"`
 - [ ] `/usr/bin/skopeo` wrapper redirecting scratch to target `@scratch` btrfs subvolume
 - [ ] `/usr/bin/podman` pass-through wrapper
 - [ ] `/var/fisherman-tmp` pre-created directory
-- [ ] dconf lock-screen keys disabled
+- [ ] dconf lock-screen/sleep keys disabled (in the correct `distro.d/` or `local.d/` for your base image)
+- [ ] systemd sleep targets masked
 - [ ] GDM autologin configured for `liveuser`
+- [ ] `org.gnome.Tour.desktop` removed to prevent gnome-tour interfering with installer

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -96,8 +96,8 @@ DAKOTA_RECIPE = {
 
 AURORA_RECIPE = {
     **_BASE_RECIPE,
-    "filesystem": "xfs",
-    "btrfsSubvolumes": False,
+    "filesystem": "btrfs",
+    "btrfsSubvolumes": True,
     "image": "ghcr.io/ublue-os/aurora:stable",
     "targetImgref": "docker://ghcr.io/ublue-os/aurora:stable",
     "composeFsBackend": False,
@@ -107,8 +107,8 @@ AURORA_RECIPE = {
 
 BLUEFIN_RECIPE = {
     **_BASE_RECIPE,
-    "filesystem": "xfs",
-    "btrfsSubvolumes": False,
+    "filesystem": "btrfs",
+    "btrfsSubvolumes": True,
     "image": "ghcr.io/ublue-os/bluefin:stable",
     "targetImgref": "docker://ghcr.io/ublue-os/bluefin:stable",
     "composeFsBackend": False,
@@ -118,8 +118,8 @@ BLUEFIN_RECIPE = {
 
 BAZZITE_RECIPE = {
     **_BASE_RECIPE,
-    "filesystem": "xfs",
-    "btrfsSubvolumes": False,
+    "filesystem": "btrfs",
+    "btrfsSubvolumes": True,
     "image": "ghcr.io/ublue-os/bazzite:stable",
     "targetImgref": "docker://ghcr.io/ublue-os/bazzite:stable",
     "composeFsBackend": False,

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -94,6 +94,39 @@ DAKOTA_RECIPE = {
     "selinuxDisabled": False,
 }
 
+AURORA_RECIPE = {
+    **_BASE_RECIPE,
+    "filesystem": "xfs",
+    "btrfsSubvolumes": False,
+    "image": "ghcr.io/ublue-os/aurora:stable",
+    "targetImgref": "docker://ghcr.io/ublue-os/aurora:stable",
+    "composeFsBackend": False,
+    "bootloader": "",
+    "selinuxDisabled": False,
+}
+
+BLUEFIN_RECIPE = {
+    **_BASE_RECIPE,
+    "filesystem": "xfs",
+    "btrfsSubvolumes": False,
+    "image": "ghcr.io/ublue-os/bluefin:stable",
+    "targetImgref": "docker://ghcr.io/ublue-os/bluefin:stable",
+    "composeFsBackend": False,
+    "bootloader": "",
+    "selinuxDisabled": False,
+}
+
+BAZZITE_RECIPE = {
+    **_BASE_RECIPE,
+    "filesystem": "xfs",
+    "btrfsSubvolumes": False,
+    "image": "ghcr.io/ublue-os/bazzite:stable",
+    "targetImgref": "docker://ghcr.io/ublue-os/bazzite:stable",
+    "composeFsBackend": False,
+    "bootloader": "",
+    "selinuxDisabled": False,
+}
+
 
 # ---------------------------------------------------------------------------
 # Skip conditions
@@ -481,6 +514,21 @@ def test_dakota_install():
     _install_image(DAKOTA_RECIPE, "Dakota", vnc_offset=12)
 
 
+def test_aurora_install():
+    """Aurora stable (grub2 + XFS) installs and optionally boots to GDM."""
+    _install_image(AURORA_RECIPE, "Aurora", vnc_offset=13)
+
+
+def test_bluefin_install():
+    """Bluefin stable (grub2 + XFS) installs and optionally boots to GDM."""
+    _install_image(BLUEFIN_RECIPE, "Bluefin", vnc_offset=14)
+
+
+def test_bazzite_install():
+    """Bazzite stable (grub2 + XFS) installs and optionally boots to GDM."""
+    _install_image(BAZZITE_RECIPE, "Bazzite", vnc_offset=15)
+
+
 # ---------------------------------------------------------------------------
 # Build helper (run standalone)
 # ---------------------------------------------------------------------------
@@ -504,8 +552,8 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="E2E install test runner")
-    parser.add_argument("--images", default="yellowfin,dakota",
-                        help="Comma-separated list of images to test (yellowfin, dakota)")
+    parser.add_argument("--images", default="yellowfin,dakota,aurora,bluefin,bazzite",
+                        help="Comma-separated list of images to test (yellowfin, dakota, aurora, bluefin, bazzite)")
     parser.add_argument("--boot-verify", action="store_true",
                         help="Boot each installed disk in QEMU and verify display")
     parser.add_argument("--build", action="store_true",
@@ -531,9 +579,11 @@ if __name__ == "__main__":
     results = {}
 
     for name in images:
-        recipe = {"yellowfin": YELLOWFIN_RECIPE, "dakota": DAKOTA_RECIPE}.get(name)
+        recipe = {"yellowfin": YELLOWFIN_RECIPE, "dakota": DAKOTA_RECIPE,
+                  "aurora": AURORA_RECIPE, "bluefin": BLUEFIN_RECIPE,
+                  "bazzite": BAZZITE_RECIPE}.get(name)
         if recipe is None:
-            print(f"Unknown image: {name!r} (choose from: yellowfin, dakota)")
+            print(f"Unknown image: {name!r} (choose from: yellowfin, dakota, aurora, bluefin, bazzite)")
             continue
         print(f"\n{'='*60}\nTesting {name}\n{'='*60}")
         try:

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -215,12 +215,20 @@ class TestWizardNavigation:
 
 # ── Full flow: finals → processor ─────────────────────────────────────────────
 
+def _set_custom_image(image_step, imgref: str):
+    """Expand the custom image row and type an imgref so get_finals() returns it."""
+    image_step.row_custom.set_expanded(True)
+    image_step.image_url_entry.set_text(imgref)
+    _pump()
+
+
 class TestEndToEnd:
     def test_recipe_generated_from_auto_disk(self, window):
         """Simulate auto-disk selection and verify processor produces valid JSON."""
         from bootc_installer.utils.processor import Processor
 
-        # Build a finals list that mimics what the wizard collects.
+        # Select an image so the recipe is valid (no default in catalog).
+        _set_custom_image(window.image_step, "ghcr.io/tuna-os/yellowfin:gnome50")
         image_finals = window.image_step.get_finals()
         disk_finals = {
             "disk": {"auto": {"disk": "/dev/vda", "pretty_size": "100 GB",
@@ -247,6 +255,8 @@ class TestEndToEnd:
         """Manual partition layout produces customMounts in the recipe."""
         from bootc_installer.utils.processor import Processor
 
+        # Select an image so the recipe is valid (no default in catalog).
+        _set_custom_image(window.image_step, "ghcr.io/tuna-os/yellowfin:gnome50")
         image_finals = window.image_step.get_finals()
         disk_finals = {
             "disk": {

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -136,10 +136,13 @@ class TestImageStep:
         assert "selected_image" in finals or "custom_image" in finals
 
     def test_default_image_selected(self, window):
+        """With no default_image in catalog, tree starts collapsed and nothing is pre-selected."""
         step = window.image_step
         finals = step.get_finals()
         image = finals.get("selected_image") or finals.get("custom_image")
-        assert image, "No default image was auto-selected"
+        assert not image, (
+            "No image should be pre-selected when default_image is absent from catalog"
+        )
 
     def test_composefs_backend_in_finals(self, window):
         step = window.image_step
@@ -174,7 +177,14 @@ class TestDiskStepButtonState:
         the page btn_next defaulted to sensitive=True and the window mirrored
         that onto the header Next button — making it clickable before any disk
         was chosen.
+
+        Skipped when Adw.ButtonRow is unavailable (libadwaita < 1.6, e.g. Ubuntu 24.04).
         """
+        try:
+            Adw.ButtonRow  # noqa: B018 — probe for ≥1.6 widget
+        except AttributeError:
+            pytest.skip("Adw.ButtonRow requires libadwaita >= 1.6")
+
         from unittest.mock import MagicMock, patch
 
         from bootc_installer.defaults.disk import VanillaDefaultDisk

--- a/tests/unit/test_image_helpers.py
+++ b/tests/unit/test_image_helpers.py
@@ -203,14 +203,16 @@ class TestImagesCatalogIntegrity(unittest.TestCase):
         self.assertEqual(bad, [], f"'Gaming' label found (use Nvidia+CUDA): {bad}")
 
     def test_default_image_present_and_valid(self):
-        """default_image must be set and must exist as a leaf in the tree.
+        """If default_image is set it must exist as a leaf in the tree.
 
-        Handles both explicit ``imgref`` leaves and ``registry``+``tag`` shorthand
-        nodes so refactored groups are covered.
+        An absent or empty default_image is valid — the tree starts fully
+        collapsed with nothing pre-selected (btn_next disabled until the
+        user picks an image).  Distros can override via their own images.json.
         """
         catalog = self._load_catalog()
         default = catalog.get("default_image", "")
-        self.assertTrue(default, "default_image is missing or empty in images.json")
+        if not default:
+            return  # fully-collapsed mode — no default required
 
         found = list(self._all_imgrefs(catalog.get("images", [])))
         self.assertIn(default, found,

--- a/tests/unit/test_image_helpers.py
+++ b/tests/unit/test_image_helpers.py
@@ -68,7 +68,7 @@ _mock_gio_data.get_data.return_value = _json.dumps(_FIXTURE_MANIFEST).encode()
 sys.modules["gi.repository"].Gio.resources_lookup_data.return_value = _mock_gio_data
 sys.modules["gi.repository"].Gio.ResourceLookupFlags.NONE = 0
 
-from bootc_installer.defaults.image import _find_icon_for_imgref  # noqa: E402
+from bootc_installer.defaults.image import _find_icon_for_imgref, _resolve_aliases  # noqa: E402
 
 
 class TestFindIconForImgref(unittest.TestCase):
@@ -112,8 +112,44 @@ class TestDistroInfoDefaultImageIcon(unittest.TestCase):
         self.assertTrue(icon.startswith("resource://"))
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestResolveAliases(unittest.TestCase):
+    """Unit tests for the @alias resolution helper."""
+
+    def test_string_value_replaced(self):
+        aliases = {"brew_url": "https://example.com/flatpaks.Brewfile"}
+        manifest = {"images": [{"name": "Foo", "flatpaks": "@brew_url"}]}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["images"][0]["flatpaks"], "https://example.com/flatpaks.Brewfile")
+
+    def test_list_value_replaced(self):
+        aliases = {"foo": "bar"}
+        obj = ["@foo", "baz", "@foo"]
+        _resolve_aliases(obj, aliases)
+        self.assertEqual(obj, ["bar", "baz", "bar"])
+
+    def test_non_alias_string_left_unchanged(self):
+        aliases = {"foo": "bar"}
+        manifest = {"name": "NoAlias", "flatpaks": "https://example.com/file"}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["flatpaks"], "https://example.com/file")
+
+    def test_unknown_alias_left_as_is(self):
+        aliases = {"known": "value"}
+        manifest = {"key": "@unknown"}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["key"], "@unknown")
+
+    def test_nested_dict_resolved(self):
+        aliases = {"url": "https://host/path"}
+        manifest = {"a": {"b": {"flatpaks": "@url"}}}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["a"]["b"]["flatpaks"], "https://host/path")
+
+    def test_empty_aliases_no_change(self):
+        aliases = {}
+        manifest = {"key": "@something"}
+        _resolve_aliases(manifest, aliases)
+        self.assertEqual(manifest["key"], "@something")
 
 
 class TestImagesCatalogIntegrity(unittest.TestCase):
@@ -144,6 +180,16 @@ class TestImagesCatalogIntegrity(unittest.TestCase):
         with open(self._CATALOG_PATH) as f:
             return _json.load(f)
 
+    def _all_imgrefs(self, nodes, registry_ctx=""):
+        """Yield every effective imgref in the tree, resolving registry+tag nodes."""
+        for n in nodes:
+            registry = n.get("registry", registry_ctx)
+            if "imgref" in n:
+                yield n["imgref"]
+            elif "tag" in n and registry:
+                yield f"{registry}:{n['tag']}"
+            yield from self._all_imgrefs(n.get("children", []), registry)
+
     def test_no_bare_ampersand_in_names(self):
         """Names must not contain bare & — it breaks Pango markup rendering."""
         catalog = self._load_catalog()
@@ -157,21 +203,59 @@ class TestImagesCatalogIntegrity(unittest.TestCase):
         self.assertEqual(bad, [], f"'Gaming' label found (use Nvidia+CUDA): {bad}")
 
     def test_default_image_present_and_valid(self):
-        """default_image must be set and must exist as a leaf imgref in the tree.
+        """default_image must be set and must exist as a leaf in the tree.
 
-        Without it _DEFAULT_IMAGE is '' and __select_default() never fires,
-        leaving the image step with no selection and breaking the UI and tests.
+        Handles both explicit ``imgref`` leaves and ``registry``+``tag`` shorthand
+        nodes so refactored groups are covered.
         """
         catalog = self._load_catalog()
         default = catalog.get("default_image", "")
         self.assertTrue(default, "default_image is missing or empty in images.json")
 
-        def all_imgrefs(nodes):
-            for n in nodes:
-                if "imgref" in n:
-                    yield n["imgref"]
-                yield from all_imgrefs(n.get("children", []))
-
-        found = list(all_imgrefs(catalog.get("images", [])))
+        found = list(self._all_imgrefs(catalog.get("images", [])))
         self.assertIn(default, found,
                       f"default_image {default!r} is not a leaf imgref in the tree")
+
+    def test_aliases_resolve_without_unknown_refs(self):
+        """Every @alias_name in the catalog must have a corresponding alias definition."""
+        catalog = self._load_catalog()
+        aliases = catalog.get("aliases", {})
+
+        def _collect_alias_refs(obj):
+            if isinstance(obj, dict):
+                for key, val in obj.items():
+                    if key == "aliases":
+                        continue  # skip the definitions dict itself
+                    yield from _collect_alias_refs(val)
+            elif isinstance(obj, list):
+                for item in obj:
+                    yield from _collect_alias_refs(item)
+            elif isinstance(obj, str) and obj.startswith("@"):
+                yield obj[1:]
+
+        unknown = [name for name in _collect_alias_refs(catalog) if name not in aliases]
+        self.assertEqual(unknown, [], f"Unknown alias references in images.json: {unknown}")
+
+    def test_registry_tag_nodes_produce_valid_imgrefs(self):
+        """Every ``tag`` node must have a ``registry`` in scope (itself or ancestor)."""
+        catalog = self._load_catalog()
+
+        def _check(nodes, registry_ctx=""):
+            for n in nodes:
+                registry = n.get("registry", registry_ctx)
+                if "tag" in n and not "imgref" in n:
+                    self.assertTrue(
+                        registry,
+                        f"Node '{n.get('name')}' has 'tag' but no registry in scope"
+                    )
+                    imgref = f"{registry}:{n['tag']}"
+                    self.assertIn(":", imgref,
+                                  f"Composed imgref '{imgref}' missing colon")
+                _check(n.get("children", []), registry)
+
+        _check(catalog.get("images", []))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Promotes all dev fixes to production:

- fix: strip double `containers-storage:` transport prefix in fisherman (#11)
- fix: use target disk for scratch on live ISOs with tmpfs /var (fisherman #9)
- fix: use `/run/host/etc` prefix when running inside Flatpak sandbox (#27)
- fix: live ISO fallback for user creation and image fields (#28)
- docs: add live ISO guide (#29)

After merge, CI will rebuild and publish a new `continuous` production flatpak.