### PR TITLE
fix: make page header icon full opacity and larger

### DIFF
--- a/bootc_installer/gtk/widget-page-header.blp
+++ b/bootc_installer/gtk/widget-page-header.blp
@@ -6,11 +6,7 @@ template $TunaPageHeader: Gtk.Box {
   halign: center;
 
   Image _icon {
-    pixel-size: 96;
-
-    styles [
-      "dim-label",
-    ]
+    pixel-size: 128;
   }
 
   Box {


### PR DESCRIPTION
## Problem
The main icon on the welcome page (and other page headers) renders semi-transparent/gray due to the `dim-label` CSS class, making it look faded.

## Fix
- Remove `dim-label` from the `_icon` Image in `widget-page-header.blp`
- Increase `pixel-size` from 96 → 128 for better visual presence