### PR TITLE
feat: filesystem dropdown and per-image default hostname

### DIFF
--- a/bootc_installer/defaults/disk.py
+++ b/bootc_installer/defaults/disk.py
@@ -672,6 +672,7 @@ class VanillaDefaultDisk(Adw.Bin):
     group_disks = Gtk.Template.Child()
     disk_space_err_box = Gtk.Template.Child()
     disk_space_err_label = Gtk.Template.Child()
+    filesystem_row = Gtk.Template.Child()
     hostname_entry = Gtk.Template.Child()
 
     _VIRTUAL_DISK_IMG = "/var/home/james/tuna-virtual-disk.img"
@@ -728,9 +729,41 @@ class VanillaDefaultDisk(Adw.Bin):
         self.btn_manual.connect("clicked", self.__on_manual_clicked)
         self.btn_exit.connect("clicked", self.__on_btn_exit_clicked)
 
+        # Populate filesystem picker and hostname from the selected image's metadata.
+        self.__filesystem_options = ["xfs"]
+        image_step = getattr(self.__window, "image_step", None)
+        if image_step is not None:
+            image_finals = image_step.get_finals()
+            supported = image_finals.get("supported_filesystems") or []
+            default_hostname = image_finals.get("default_hostname") or ""
+            if default_hostname:
+                self.hostname_entry.set_text(default_hostname)
+            self.__setup_filesystem_row(supported)
+
         # Auto-select virtual disk if still no physical disks are available
         if not self.__registry_disks:
             self.__select_virtual_disk()
+
+    def __setup_filesystem_row(self, filesystems):
+        """Show a filesystem picker when the selected image supports multiple rootfs types."""
+        self.__filesystem_options = filesystems if filesystems else ["xfs"]
+        if len(self.__filesystem_options) <= 1:
+            self.filesystem_row.set_visible(False)
+            return
+
+        _LABELS = {"xfs": "XFS", "btrfs": "Btrfs (with subvolumes)"}
+        model = Gtk.StringList.new([_LABELS.get(fs, fs.upper()) for fs in self.__filesystem_options])
+        self.filesystem_row.set_model(model)
+        self.filesystem_row.set_selected(0)
+        self.filesystem_row.set_visible(True)
+
+    def __get_selected_filesystem(self):
+        if not self.filesystem_row.get_visible():
+            return self.__filesystem_options[0] if self.__filesystem_options else "xfs"
+        idx = self.filesystem_row.get_selected()
+        if 0 <= idx < len(self.__filesystem_options):
+            return self.__filesystem_options[idx]
+        return "xfs"
 
     def __on_btn_exit_clicked(self, button):
         self.__window.get_application().quit()
@@ -819,9 +852,14 @@ class VanillaDefaultDisk(Adw.Bin):
             return None
 
     def get_finals(self):
+        fs = self.__get_selected_filesystem()
+        disk = dict(self.__partition_recipe) if self.__partition_recipe else {}
+        if "auto" in disk:
+            disk["filesystem"] = fs
+            disk["btrfsSubvolumes"] = (fs == "btrfs")
         result = {
-            "disk": self.__partition_recipe,
-            "hostname": self.hostname_entry.get_text().strip() or "tunaos",
+            "disk": disk,
+            "hostname": self.hostname_entry.get_text().strip() or "localhost",
         }
         if self.__use_virtual_disk:
             result["virtual_disk_img"] = self._VIRTUAL_DISK_IMG

--- a/bootc_installer/defaults/disk.py
+++ b/bootc_installer/defaults/disk.py
@@ -730,19 +730,32 @@ class VanillaDefaultDisk(Adw.Bin):
         self.btn_exit.connect("clicked", self.__on_btn_exit_clicked)
 
         # Populate filesystem picker and hostname from the selected image's metadata.
+        # We do the initial setup now, but also refresh when this page becomes active
+        # (image selection happens on the previous step, so __init__ runs too early).
         self.__filesystem_options = ["xfs"]
-        image_step = getattr(self.__window, "image_step", None)
-        if image_step is not None:
-            image_finals = image_step.get_finals()
-            supported = image_finals.get("supported_filesystems") or []
-            default_hostname = image_finals.get("default_hostname") or ""
-            if default_hostname:
-                self.hostname_entry.set_text(default_hostname)
-            self.__setup_filesystem_row(supported)
+        self.__window.carousel.connect("page-changed", self.__on_carousel_page_changed)
+        self.__refresh_from_image_step()
 
         # Auto-select virtual disk if still no physical disks are available
         if not self.__registry_disks:
             self.__select_virtual_disk()
+
+    def __on_carousel_page_changed(self, carousel, idx):
+        if carousel.get_nth_page(idx) is self:
+            self.__refresh_from_image_step()
+
+    def __refresh_from_image_step(self):
+        """Re-read image metadata and update filesystem picker and hostname."""
+        image_step = getattr(self.__window, "image_step", None)
+        if image_step is None:
+            return
+        finals = image_step.get_finals()
+        supported = finals.get("supported_filesystems") or []
+        default_hostname = finals.get("default_hostname") or ""
+        current = self.hostname_entry.get_text().strip()
+        if default_hostname and current in ("", "localhost"):
+            self.hostname_entry.set_text(default_hostname)
+        self.__setup_filesystem_row(supported)
 
     def __setup_filesystem_row(self, filesystems):
         """Show a filesystem picker when the selected image supports multiple rootfs types."""

--- a/bootc_installer/defaults/image.py
+++ b/bootc_installer/defaults/image.py
@@ -291,8 +291,10 @@ class VanillaDefaultImage(Adw.Bin):
         self.__selected_image_filesystem = ""       # filesystem required by image, or ""
         self.__selected_icon = None      # icon spec for selected image (str or None)
         self.__selected_pretty_name = _imgref_to_pretty_name(_DEFAULT_IMAGE)
+        self.__selected_default_hostname = ""       # suggested hostname from images.json
+        self.__selected_filesystems = []            # user-selectable filesystems from images.json
         self.__all_expanders = []   # every ExpanderRow widget
-        self.__leaf_rows = []       # [(row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, search_str, [ancestor_exps])]
+        self.__leaf_rows = []       # [(row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems, search_str, [ancestor_exps])]
 
         # Hidden anchor for the radio CheckButton group.
         self.__radio_anchor = Gtk.CheckButton()
@@ -334,9 +336,9 @@ class VanillaDefaultImage(Adw.Bin):
                     img.get("description", ""), "", [exp])
             self.list_images.append(exp)
 
-    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx="", registry_ctx=""):
+    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx="", registry_ctx="", default_hostname_ctx="", filesystems_ctx=None):
         """Recursively build ExpanderRow groups and ActionRow leaves."""
-        # Inherit flatpaks, icon, carousel, needs_user_creation, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, and registry from nearest ancestor.
+        # Inherit all per-image metadata from nearest ancestor that defines each field.
         node_flatpaks = node.get("flatpaks", flatpaks_ctx)
         node_icon = node.get("icon", icon_ctx)
         node_carousel = node.get("carousel", carousel_ctx)
@@ -347,6 +349,8 @@ class VanillaDefaultImage(Adw.Bin):
         node_image_filesystem = node.get("filesystem", image_filesystem_ctx)
         node_flatpak_var_path = node.get("flatpak_var_path", flatpak_var_path_ctx)
         node_registry = node.get("registry", registry_ctx)
+        node_default_hostname = node.get("default_hostname", default_hostname_ctx)
+        node_filesystems = node.get("filesystems", filesystems_ctx if filesystems_ctx is not None else [])
 
         # A leaf can use "tag" instead of a full "imgref" when a "registry" is
         # available from this node or an ancestor.  The full imgref is composed
@@ -366,7 +370,7 @@ class VanillaDefaultImage(Adw.Bin):
                             node.get("desc", ""), search_ctx, ancestors,
                             node_flatpaks, node_icon, node_carousel, node_needs_user,
                             node_composefs, node_image_type, node_bootloader, node_image_filesystem,
-                            node_flatpak_var_path)
+                            node_flatpak_var_path, node_default_hostname, node_filesystems)
             return
 
         exp = Adw.ExpanderRow(title=node["name"])
@@ -388,7 +392,7 @@ class VanillaDefaultImage(Adw.Bin):
         child_ancestors = ancestors + [exp]
 
         for child in node.get("children", []):
-            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path, node_registry)
+            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path, node_registry, node_default_hostname, node_filesystems)
 
         if parent is self.list_images:
             parent.append(exp)
@@ -398,7 +402,7 @@ class VanillaDefaultImage(Adw.Bin):
     def __add_leaf(self, parent, name, imgref, desc, search_ctx, ancestors,
                    flatpaks=None, icon=None, carousel=None, needs_user=False,
                    composefs=False, image_type="bootc", bootloader="", image_filesystem="",
-                   flatpak_var_path=""):
+                   flatpak_var_path="", default_hostname="", filesystems=None):
         search_str = f"{search_ctx} {name} {desc} {imgref}".lower()
 
         row = Adw.ActionRow(title=name, subtitle=imgref)
@@ -410,7 +414,7 @@ class VanillaDefaultImage(Adw.Bin):
         check.set_group(self.__radio_anchor)
         row.add_prefix(check)
         row.set_activatable_widget(check)
-        check.connect("toggled", self.__on_check_toggled, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path)
+        check.connect("toggled", self.__on_check_toggled, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems or [])
 
         # Leaf icon — only for nodes that explicitly define one (e.g. TunaOS variants).
         if icon:
@@ -419,10 +423,10 @@ class VanillaDefaultImage(Adw.Bin):
                 row.add_suffix(img)
 
         parent.add_row(row)
-        self.__leaf_rows.append((row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, search_str, list(ancestors)))
+        self.__leaf_rows.append((row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems or [], search_str, list(ancestors)))
 
     def __select_default(self):
-        for _row, check, imgref, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, _search, ancestors in self.__leaf_rows:
+        for _row, check, imgref, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, _hostname, _filesystems, _search, ancestors in self.__leaf_rows:
             if imgref == _DEFAULT_IMAGE:
                 check.set_active(True)
                 for exp in ancestors:
@@ -432,7 +436,7 @@ class VanillaDefaultImage(Adw.Bin):
 
     # ── Selection handlers ────────────────────────────────────────────────────
 
-    def __on_check_toggled(self, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path):
+    def __on_check_toggled(self, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems):
         if check.get_active():
             self.__selected_imgref = imgref
             self.__selected_icon = icon
@@ -444,6 +448,8 @@ class VanillaDefaultImage(Adw.Bin):
             self.__selected_image_filesystem = image_filesystem
             self.__selected_flatpak_var_path = flatpak_var_path or ""
             self.__selected_pretty_name = _imgref_to_pretty_name(imgref)
+            self.__selected_default_hostname = default_hostname or ""
+            self.__selected_filesystems = filesystems or []
             # flatpaks may be a list of app IDs or a URL string pointing to a remote list.
             if isinstance(flatpaks, str) and flatpaks.startswith("http"):
                 self.__selected_flatpaks = _fetch_remote_flatpak_list(flatpaks)
@@ -466,6 +472,8 @@ class VanillaDefaultImage(Adw.Bin):
             self.__selected_bootloader = ""
             self.__selected_image_filesystem = ""
             self.__selected_pretty_name = None
+            self.__selected_default_hostname = ""
+            self.__selected_filesystems = []
         self.__update_btn_next()
 
     def __on_url_changed(self, entry):
@@ -486,14 +494,14 @@ class VanillaDefaultImage(Adw.Bin):
             for exp in self.__all_expanders:
                 exp.set_visible(True)
                 exp.set_expanded(False)
-            for row, _, _, _, _, _, _, _, _, _, _, _, _, _ in self.__leaf_rows:
+            for row, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ in self.__leaf_rows:
                 row.set_visible(True)
             self.__expand_default_path()
             return
 
         # Determine which leaves match and which expanders are needed.
         visible_expanders = set()
-        for row, _, _, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, search_str, ancestors in self.__leaf_rows:
+        for row, _, _, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, _hostname, _filesystems, search_str, ancestors in self.__leaf_rows:
             if query in search_str:
                 row.set_visible(True)
                 for exp in ancestors:
@@ -509,7 +517,7 @@ class VanillaDefaultImage(Adw.Bin):
                 exp.set_visible(False)
 
     def __expand_default_path(self):
-        for _, _, imgref, _, _, _, _, _, _, _, _, _, _, ancestors in self.__leaf_rows:
+        for _, _, imgref, _, _, _, _, _, _, _, _, _, _, _, _, ancestors in self.__leaf_rows:
             if imgref == _DEFAULT_IMAGE:
                 for exp in ancestors:
                     exp.set_expanded(True)
@@ -569,5 +577,7 @@ class VanillaDefaultImage(Adw.Bin):
             "bootloader": self.__selected_bootloader,
             "image_filesystem": self.__selected_image_filesystem,
             "icon": self.__selected_icon,
+            "default_hostname": self.__selected_default_hostname,
+            "supported_filesystems": self.__selected_filesystems,
         }
 

--- a/bootc_installer/defaults/welcome.py
+++ b/bootc_installer/defaults/welcome.py
@@ -39,12 +39,12 @@ class VanillaDefaultWelcome(Adw.Bin):
         self.__step = step
         self.delta = False
 
-        distro_name = self.__distro_info.get("name", "TunaOS")
         fallback_logo = self.__distro_info.get("logo", "org.bootcinstaller.Installer")
         icon_spec = self.__distro_info.get("default_image_icon") or fallback_logo
 
         apply_icon(self.page_header, icon_spec)
-        self.page_header.title = f"Welcome to {distro_name}!"
+        welcome_title = self.__distro_info.get("welcome_title") or "bootc Installer"
+        self.page_header.title = welcome_title
 
         # signals
         self.row_install.connect("activated", self.__install)

--- a/bootc_installer/gtk/default-disk.blp
+++ b/bootc_installer/gtk/default-disk.blp
@@ -114,9 +114,14 @@ template $VanillaDefaultDisk: Adw.Bin {
         Adw.PreferencesGroup {
           title: _("System");
 
+          Adw.ComboRow filesystem_row {
+            title: _("Root Filesystem");
+            visible: false;
+          }
+
           Adw.EntryRow hostname_entry {
             title: _("Hostname");
-            text: "tunaos";
+            text: "localhost";
           }
         }
       }

--- a/bootc_installer/utils/builder.py
+++ b/bootc_installer/utils/builder.py
@@ -150,4 +150,5 @@ class Builder:
             "name": self.__recipe.raw["distro_name"],
             "logo": self.__recipe.raw["distro_logo"],
             "default_image_icon": default_image_icon,
+            "welcome_title": self.__recipe.raw.get("welcome_title", ""),
         }

--- a/recipe.json
+++ b/recipe.json
@@ -2,6 +2,7 @@
     "log_file": "/var/log/bootc-installer.log",
     "distro_name": "TunaOS",
     "distro_logo": "org.bootcinstaller.Installer",
+    "welcome_title": "Welcome to TunaOS!",
     "tour": {
         "welcome": {
             "resource": "/org/bootcinstaller/Installer/assets/welcome.png",

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -26,7 +26,11 @@ def _auto_finals(disk="/dev/vda", fs="xfs", image="ghcr.io/tuna-os/yellowfin:gno
                  composefs=False, image_type="bootc", bootloader="", image_filesystem="",
                  flatpak_var_path=""):
     d = {
-        "disk": {"auto": {"disk": disk, "pretty_size": "100 GB", "size": 100_000_000_000}},
+        "disk": {
+            "auto": {"disk": disk, "pretty_size": "100 GB", "size": 100_000_000_000},
+            "filesystem": fs,
+            "btrfsSubvolumes": fs == "btrfs",
+        },
         "selected_image": image,
         "hostname": hostname,
         "flatpaks": flatpaks or [],
@@ -99,7 +103,7 @@ class TestAutoDisk:
                    "encryption": {"use_encryption": False}}]
         path = Processor.gen_install_recipe("log", finals, _SYS_RECIPE)
         r = _load(path)
-        assert r["hostname"] == "tunaos"
+        assert r["hostname"] == "tunaos"  # sys recipe still provides distro_name fallback
 
 
 # ── Encryption tests ───────────────────────────────────────────────────────────
@@ -304,6 +308,23 @@ class TestComposefs:
             "log", _auto_finals(fs="xfs", image_filesystem=""), _SYS_RECIPE)
         r = _load(path)
         assert r["filesystem"] == "xfs"
+
+    def test_disk_step_btrfs_selection(self):
+        # When the disk step picks btrfs (user chose it from filesystem dropdown),
+        # the recipe must reflect btrfs + subvolumes=True.
+        path = Processor.gen_install_recipe(
+            "log", _auto_finals(fs="btrfs"), _SYS_RECIPE)
+        r = _load(path)
+        assert r["filesystem"] == "btrfs"
+        assert r["btrfsSubvolumes"] is True
+
+    def test_disk_step_xfs_no_subvolumes(self):
+        # XFS selection must never set btrfsSubvolumes=True.
+        path = Processor.gen_install_recipe(
+            "log", _auto_finals(fs="xfs"), _SYS_RECIPE)
+        r = _load(path)
+        assert r["filesystem"] == "xfs"
+        assert r.get("btrfsSubvolumes", False) is False
 
     def test_dakota_recipe_fields(self):
         """Simulate a Dakota image selection producing the full expected recipe."""


### PR DESCRIPTION
## Summary

### images.json (fisherman submodule, PR #12)
Each distro group now declares:
- `default_hostname`: suggested hostname pre-filled in the disk step
- `filesystems`: list of user-selectable rootfs formats (only for images that genuinely support multiple — Albacore and Yellowfin get `["xfs", "btrfs"]`; btrfs-locked images keep their existing `filesystem` lock)

Both fields inherit down the tree so leaf nodes pick up values without redundancy.

### Frontend changes
- **image.py**: `default_hostname` and `supported_filesystems` propagate through the full node/leaf inheritance chain and appear in `get_finals()`
- **default-disk.blp**: new hidden `Adw.ComboRow filesystem_row` in the System group
- **disk.py**: at init, queries `window.image_step` for `default_hostname` (pre-fills hostname entry) and `supported_filesystems` (shows filesystem picker with XFS / Btrfs (with subvolumes) when >1 option); `get_finals()` embeds `filesystem` and `btrfsSubvolumes` in the auto disk dict
- **test_processor.py**: `_auto_finals` now correctly places `filesystem`/`btrfsSubvolumes` inside the disk dict; two new regression tests for btrfs/xfs selection