### PR TITLE
chore: promote dev to prod

### DIFF
--- a/bootc_installer/defaults/disk.py
+++ b/bootc_installer/defaults/disk.py
@@ -785,10 +785,12 @@ class VanillaDefaultDisk(Adw.Bin):
         self.__check_fs_tool(self.__get_selected_filesystem())
 
     def __check_fs_tool(self, fs):
-        """Show a banner and block Next if the required mkfs tool for *fs* is missing."""
+        """Highlight the filesystem row and block Next if the required mkfs tool is missing."""
         tool, pkg = self._FS_TOOLS.get(fs, (None, None))
         if tool is None:
             self.__fs_tool_ok = True
+            self.filesystem_row.remove_css_class("error")
+            self.filesystem_row.set_subtitle("")
             self.fs_tool_error_banner.set_visible(False)
             self.__update_next_button()
             return
@@ -803,8 +805,14 @@ class VanillaDefaultDisk(Adw.Bin):
             available = True  # assume available if check fails
         self.__fs_tool_ok = available
         if available:
+            self.filesystem_row.remove_css_class("error")
+            self.filesystem_row.set_subtitle("")
             self.fs_tool_error_banner.set_visible(False)
         else:
+            self.filesystem_row.add_css_class("error")
+            self.filesystem_row.set_subtitle(
+                _('Install the "{}" package on the host to use this filesystem').format(pkg)
+            )
             self.fs_tool_error_banner.set_title(
                 _('Missing host tool: "{}" — install the "{}" package').format(tool, pkg)
             )

--- a/bootc_installer/defaults/disk.py
+++ b/bootc_installer/defaults/disk.py
@@ -673,6 +673,7 @@ class VanillaDefaultDisk(Adw.Bin):
     disk_space_err_box = Gtk.Template.Child()
     disk_space_err_label = Gtk.Template.Child()
     filesystem_row = Gtk.Template.Child()
+    fs_tool_error_banner = Gtk.Template.Child()
     hostname_entry = Gtk.Template.Child()
 
     _VIRTUAL_DISK_IMG = "/var/home/james/tuna-virtual-disk.img"
@@ -757,11 +758,18 @@ class VanillaDefaultDisk(Adw.Bin):
             self.hostname_entry.set_text(default_hostname)
         self.__setup_filesystem_row(supported)
 
+    # Maps filesystem type → (required tool, package name)
+    _FS_TOOLS = {
+        "xfs": ("mkfs.xfs", "xfsprogs"),
+        "btrfs": ("mkfs.btrfs", "btrfs-progs"),
+    }
+
     def __setup_filesystem_row(self, filesystems):
         """Show a filesystem picker when the selected image supports multiple rootfs types."""
         self.__filesystem_options = filesystems if filesystems else ["xfs"]
         if len(self.__filesystem_options) <= 1:
             self.filesystem_row.set_visible(False)
+            self.__check_fs_tool(self.__filesystem_options[0] if self.__filesystem_options else "xfs")
             return
 
         _LABELS = {"xfs": "XFS", "btrfs": "Btrfs (with subvolumes)"}
@@ -769,6 +777,34 @@ class VanillaDefaultDisk(Adw.Bin):
         self.filesystem_row.set_model(model)
         self.filesystem_row.set_selected(0)
         self.filesystem_row.set_visible(True)
+        self.filesystem_row.connect("notify::selected", self.__on_filesystem_changed)
+        self.__check_fs_tool(self.__filesystem_options[0])
+
+    def __on_filesystem_changed(self, row, _pspec):
+        self.__check_fs_tool(self.__get_selected_filesystem())
+
+    def __check_fs_tool(self, fs):
+        """Show a banner if the required mkfs tool for *fs* is missing on the host."""
+        tool, pkg = self._FS_TOOLS.get(fs, (None, None))
+        if tool is None:
+            self.fs_tool_error_banner.set_visible(False)
+            return
+        try:
+            result = subprocess.run(
+                ["flatpak-spawn", "--host", "sh", "-c", f"command -v {tool}"],
+                capture_output=True,
+                timeout=3,
+            )
+            available = result.returncode == 0
+        except Exception:
+            available = True  # assume available if check fails
+        if available:
+            self.fs_tool_error_banner.set_visible(False)
+        else:
+            self.fs_tool_error_banner.set_title(
+                _('Missing host tool: "{}" — install the "{}" package').format(tool, pkg)
+            )
+            self.fs_tool_error_banner.set_visible(True)
 
     def __get_selected_filesystem(self):
         if not self.filesystem_row.get_visible():

--- a/bootc_installer/defaults/disk.py
+++ b/bootc_installer/defaults/disk.py
@@ -672,6 +672,7 @@ class VanillaDefaultDisk(Adw.Bin):
     group_disks = Gtk.Template.Child()
     disk_space_err_box = Gtk.Template.Child()
     disk_space_err_label = Gtk.Template.Child()
+    filesystem_row = Gtk.Template.Child()
     hostname_entry = Gtk.Template.Child()
 
     _VIRTUAL_DISK_IMG = "/var/home/james/tuna-virtual-disk.img"
@@ -728,9 +729,54 @@ class VanillaDefaultDisk(Adw.Bin):
         self.btn_manual.connect("clicked", self.__on_manual_clicked)
         self.btn_exit.connect("clicked", self.__on_btn_exit_clicked)
 
+        # Populate filesystem picker and hostname from the selected image's metadata.
+        # We do the initial setup now, but also refresh when this page becomes active
+        # (image selection happens on the previous step, so __init__ runs too early).
+        self.__filesystem_options = ["xfs"]
+        self.__window.carousel.connect("page-changed", self.__on_carousel_page_changed)
+        self.__refresh_from_image_step()
+
         # Auto-select virtual disk if still no physical disks are available
         if not self.__registry_disks:
             self.__select_virtual_disk()
+
+    def __on_carousel_page_changed(self, carousel, idx):
+        if carousel.get_nth_page(idx) is self:
+            self.__refresh_from_image_step()
+
+    def __refresh_from_image_step(self):
+        """Re-read image metadata and update filesystem picker and hostname."""
+        image_step = getattr(self.__window, "image_step", None)
+        if image_step is None:
+            return
+        finals = image_step.get_finals()
+        supported = finals.get("supported_filesystems") or []
+        default_hostname = finals.get("default_hostname") or ""
+        current = self.hostname_entry.get_text().strip()
+        if default_hostname and current in ("", "localhost"):
+            self.hostname_entry.set_text(default_hostname)
+        self.__setup_filesystem_row(supported)
+
+    def __setup_filesystem_row(self, filesystems):
+        """Show a filesystem picker when the selected image supports multiple rootfs types."""
+        self.__filesystem_options = filesystems if filesystems else ["xfs"]
+        if len(self.__filesystem_options) <= 1:
+            self.filesystem_row.set_visible(False)
+            return
+
+        _LABELS = {"xfs": "XFS", "btrfs": "Btrfs (with subvolumes)"}
+        model = Gtk.StringList.new([_LABELS.get(fs, fs.upper()) for fs in self.__filesystem_options])
+        self.filesystem_row.set_model(model)
+        self.filesystem_row.set_selected(0)
+        self.filesystem_row.set_visible(True)
+
+    def __get_selected_filesystem(self):
+        if not self.filesystem_row.get_visible():
+            return self.__filesystem_options[0] if self.__filesystem_options else "xfs"
+        idx = self.filesystem_row.get_selected()
+        if 0 <= idx < len(self.__filesystem_options):
+            return self.__filesystem_options[idx]
+        return "xfs"
 
     def __on_btn_exit_clicked(self, button):
         self.__window.get_application().quit()
@@ -819,9 +865,14 @@ class VanillaDefaultDisk(Adw.Bin):
             return None
 
     def get_finals(self):
+        fs = self.__get_selected_filesystem()
+        disk = dict(self.__partition_recipe) if self.__partition_recipe else {}
+        if "auto" in disk:
+            disk["filesystem"] = fs
+            disk["btrfsSubvolumes"] = (fs == "btrfs")
         result = {
-            "disk": self.__partition_recipe,
-            "hostname": self.hostname_entry.get_text().strip() or "tunaos",
+            "disk": disk,
+            "hostname": self.hostname_entry.get_text().strip() or "localhost",
         }
         if self.__use_virtual_disk:
             result["virtual_disk_img"] = self._VIRTUAL_DISK_IMG

--- a/bootc_installer/defaults/disk.py
+++ b/bootc_installer/defaults/disk.py
@@ -692,6 +692,7 @@ class VanillaDefaultDisk(Adw.Bin):
         self.__partition_recipe = None
         self.__selected_disks_sum = 0
         self.__use_virtual_disk = False
+        self.__fs_tool_ok = True  # optimistic default; updated by __check_fs_tool
 
         self.min_disk_size = self.__window.recipe.get("min_disk_size", 51200)
         self.disk_space_err_label.set_label(
@@ -784,10 +785,12 @@ class VanillaDefaultDisk(Adw.Bin):
         self.__check_fs_tool(self.__get_selected_filesystem())
 
     def __check_fs_tool(self, fs):
-        """Show a banner if the required mkfs tool for *fs* is missing on the host."""
+        """Show a banner and block Next if the required mkfs tool for *fs* is missing."""
         tool, pkg = self._FS_TOOLS.get(fs, (None, None))
         if tool is None:
+            self.__fs_tool_ok = True
             self.fs_tool_error_banner.set_visible(False)
+            self.__update_next_button()
             return
         try:
             result = subprocess.run(
@@ -798,6 +801,7 @@ class VanillaDefaultDisk(Adw.Bin):
             available = result.returncode == 0
         except Exception:
             available = True  # assume available if check fails
+        self.__fs_tool_ok = available
         if available:
             self.fs_tool_error_banner.set_visible(False)
         else:
@@ -805,6 +809,13 @@ class VanillaDefaultDisk(Adw.Bin):
                 _('Missing host tool: "{}" — install the "{}" package').format(tool, pkg)
             )
             self.fs_tool_error_banner.set_visible(True)
+        self.__update_next_button()
+
+    def __update_next_button(self):
+        """Enable Next only when a partition recipe exists and the fs tool is present."""
+        ok = self.__partition_recipe is not None and self.__fs_tool_ok
+        self.btn_next.set_visible(ok)
+        self.btn_next.set_sensitive(ok)
 
     def __get_selected_filesystem(self):
         if not self.filesystem_row.get_visible():
@@ -924,8 +935,7 @@ class VanillaDefaultDisk(Adw.Bin):
                 self.__registry_disks.append(entry)
 
     def __on_close_default_disk_part_modal(self, *args):
-        self.btn_next.set_visible(self.__partition_recipe is not None)
-        self.btn_next.set_sensitive(self.__partition_recipe is not None)
+        self.__update_next_button()
         self.confirm_partition_changes()
 
     def __on_auto_clicked(self, button):

--- a/bootc_installer/defaults/image.py
+++ b/bootc_installer/defaults/image.py
@@ -291,8 +291,10 @@ class VanillaDefaultImage(Adw.Bin):
         self.__selected_image_filesystem = ""       # filesystem required by image, or ""
         self.__selected_icon = None      # icon spec for selected image (str or None)
         self.__selected_pretty_name = _imgref_to_pretty_name(_DEFAULT_IMAGE)
+        self.__selected_default_hostname = ""       # suggested hostname from images.json
+        self.__selected_filesystems = []            # user-selectable filesystems from images.json
         self.__all_expanders = []   # every ExpanderRow widget
-        self.__leaf_rows = []       # [(row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, search_str, [ancestor_exps])]
+        self.__leaf_rows = []       # [(row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems, search_str, [ancestor_exps])]
 
         # Hidden anchor for the radio CheckButton group.
         self.__radio_anchor = Gtk.CheckButton()
@@ -334,9 +336,9 @@ class VanillaDefaultImage(Adw.Bin):
                     img.get("description", ""), "", [exp])
             self.list_images.append(exp)
 
-    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx="", registry_ctx=""):
+    def __build_node(self, parent, node, ancestors, search_ctx, flatpaks_ctx=None, icon_ctx=None, carousel_ctx=None, needs_user_ctx=False, composefs_ctx=False, image_type_ctx="bootc", bootloader_ctx="", image_filesystem_ctx="", flatpak_var_path_ctx="", registry_ctx="", default_hostname_ctx="", filesystems_ctx=None):
         """Recursively build ExpanderRow groups and ActionRow leaves."""
-        # Inherit flatpaks, icon, carousel, needs_user_creation, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, and registry from nearest ancestor.
+        # Inherit all per-image metadata from nearest ancestor that defines each field.
         node_flatpaks = node.get("flatpaks", flatpaks_ctx)
         node_icon = node.get("icon", icon_ctx)
         node_carousel = node.get("carousel", carousel_ctx)
@@ -347,6 +349,8 @@ class VanillaDefaultImage(Adw.Bin):
         node_image_filesystem = node.get("filesystem", image_filesystem_ctx)
         node_flatpak_var_path = node.get("flatpak_var_path", flatpak_var_path_ctx)
         node_registry = node.get("registry", registry_ctx)
+        node_default_hostname = node.get("default_hostname", default_hostname_ctx)
+        node_filesystems = node.get("filesystems", filesystems_ctx if filesystems_ctx is not None else [])
 
         # A leaf can use "tag" instead of a full "imgref" when a "registry" is
         # available from this node or an ancestor.  The full imgref is composed
@@ -366,7 +370,7 @@ class VanillaDefaultImage(Adw.Bin):
                             node.get("desc", ""), search_ctx, ancestors,
                             node_flatpaks, node_icon, node_carousel, node_needs_user,
                             node_composefs, node_image_type, node_bootloader, node_image_filesystem,
-                            node_flatpak_var_path)
+                            node_flatpak_var_path, node_default_hostname, node_filesystems)
             return
 
         exp = Adw.ExpanderRow(title=node["name"])
@@ -388,7 +392,7 @@ class VanillaDefaultImage(Adw.Bin):
         child_ancestors = ancestors + [exp]
 
         for child in node.get("children", []):
-            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path, node_registry)
+            self.__build_node(exp, child, child_ancestors, child_ctx, node_flatpaks, node_icon, node_carousel, node_needs_user, node_composefs, node_image_type, node_bootloader, node_image_filesystem, node_flatpak_var_path, node_registry, node_default_hostname, node_filesystems)
 
         if parent is self.list_images:
             parent.append(exp)
@@ -398,7 +402,7 @@ class VanillaDefaultImage(Adw.Bin):
     def __add_leaf(self, parent, name, imgref, desc, search_ctx, ancestors,
                    flatpaks=None, icon=None, carousel=None, needs_user=False,
                    composefs=False, image_type="bootc", bootloader="", image_filesystem="",
-                   flatpak_var_path=""):
+                   flatpak_var_path="", default_hostname="", filesystems=None):
         search_str = f"{search_ctx} {name} {desc} {imgref}".lower()
 
         row = Adw.ActionRow(title=name, subtitle=imgref)
@@ -410,7 +414,7 @@ class VanillaDefaultImage(Adw.Bin):
         check.set_group(self.__radio_anchor)
         row.add_prefix(check)
         row.set_activatable_widget(check)
-        check.connect("toggled", self.__on_check_toggled, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path)
+        check.connect("toggled", self.__on_check_toggled, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems or [])
 
         # Leaf icon — only for nodes that explicitly define one (e.g. TunaOS variants).
         if icon:
@@ -419,10 +423,10 @@ class VanillaDefaultImage(Adw.Bin):
                 row.add_suffix(img)
 
         parent.add_row(row)
-        self.__leaf_rows.append((row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, search_str, list(ancestors)))
+        self.__leaf_rows.append((row, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems or [], search_str, list(ancestors)))
 
     def __select_default(self):
-        for _row, check, imgref, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, _search, ancestors in self.__leaf_rows:
+        for _row, check, imgref, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, _hostname, _filesystems, _search, ancestors in self.__leaf_rows:
             if imgref == _DEFAULT_IMAGE:
                 check.set_active(True)
                 for exp in ancestors:
@@ -432,7 +436,7 @@ class VanillaDefaultImage(Adw.Bin):
 
     # ── Selection handlers ────────────────────────────────────────────────────
 
-    def __on_check_toggled(self, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path):
+    def __on_check_toggled(self, check, imgref, flatpaks, icon, carousel, needs_user, composefs, image_type, bootloader, image_filesystem, flatpak_var_path, default_hostname, filesystems):
         if check.get_active():
             self.__selected_imgref = imgref
             self.__selected_icon = icon
@@ -444,6 +448,8 @@ class VanillaDefaultImage(Adw.Bin):
             self.__selected_image_filesystem = image_filesystem
             self.__selected_flatpak_var_path = flatpak_var_path or ""
             self.__selected_pretty_name = _imgref_to_pretty_name(imgref)
+            self.__selected_default_hostname = default_hostname or ""
+            self.__selected_filesystems = filesystems or []
             # flatpaks may be a list of app IDs or a URL string pointing to a remote list.
             if isinstance(flatpaks, str) and flatpaks.startswith("http"):
                 self.__selected_flatpaks = _fetch_remote_flatpak_list(flatpaks)
@@ -466,6 +472,8 @@ class VanillaDefaultImage(Adw.Bin):
             self.__selected_bootloader = ""
             self.__selected_image_filesystem = ""
             self.__selected_pretty_name = None
+            self.__selected_default_hostname = ""
+            self.__selected_filesystems = []
         self.__update_btn_next()
 
     def __on_url_changed(self, entry):
@@ -486,14 +494,14 @@ class VanillaDefaultImage(Adw.Bin):
             for exp in self.__all_expanders:
                 exp.set_visible(True)
                 exp.set_expanded(False)
-            for row, _, _, _, _, _, _, _, _, _, _, _, _, _ in self.__leaf_rows:
+            for row, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ in self.__leaf_rows:
                 row.set_visible(True)
             self.__expand_default_path()
             return
 
         # Determine which leaves match and which expanders are needed.
         visible_expanders = set()
-        for row, _, _, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, search_str, ancestors in self.__leaf_rows:
+        for row, _, _, _flatpaks, _icon, _carousel, _needs_user, _composefs, _image_type, _bootloader, _image_filesystem, _flatpak_var_path, _hostname, _filesystems, search_str, ancestors in self.__leaf_rows:
             if query in search_str:
                 row.set_visible(True)
                 for exp in ancestors:
@@ -509,7 +517,7 @@ class VanillaDefaultImage(Adw.Bin):
                 exp.set_visible(False)
 
     def __expand_default_path(self):
-        for _, _, imgref, _, _, _, _, _, _, _, _, _, _, ancestors in self.__leaf_rows:
+        for _, _, imgref, _, _, _, _, _, _, _, _, _, _, _, _, ancestors in self.__leaf_rows:
             if imgref == _DEFAULT_IMAGE:
                 for exp in ancestors:
                     exp.set_expanded(True)
@@ -569,5 +577,7 @@ class VanillaDefaultImage(Adw.Bin):
             "bootloader": self.__selected_bootloader,
             "image_filesystem": self.__selected_image_filesystem,
             "icon": self.__selected_icon,
+            "default_hostname": self.__selected_default_hostname,
+            "supported_filesystems": self.__selected_filesystems,
         }
 

--- a/bootc_installer/defaults/welcome.py
+++ b/bootc_installer/defaults/welcome.py
@@ -39,12 +39,12 @@ class VanillaDefaultWelcome(Adw.Bin):
         self.__step = step
         self.delta = False
 
-        distro_name = self.__distro_info.get("name", "TunaOS")
         fallback_logo = self.__distro_info.get("logo", "org.bootcinstaller.Installer")
         icon_spec = self.__distro_info.get("default_image_icon") or fallback_logo
 
         apply_icon(self.page_header, icon_spec)
-        self.page_header.title = f"Welcome to {distro_name}!"
+        welcome_title = self.__distro_info.get("welcome_title") or "bootc Installer"
+        self.page_header.title = welcome_title
 
         # signals
         self.row_install.connect("activated", self.__install)

--- a/bootc_installer/gtk/default-disk.blp
+++ b/bootc_installer/gtk/default-disk.blp
@@ -114,9 +114,14 @@ template $VanillaDefaultDisk: Adw.Bin {
         Adw.PreferencesGroup {
           title: _("System");
 
+          Adw.ComboRow filesystem_row {
+            title: _("Root Filesystem");
+            visible: false;
+          }
+
           Adw.EntryRow hostname_entry {
             title: _("Hostname");
-            text: "tunaos";
+            text: "localhost";
           }
         }
       }

--- a/bootc_installer/gtk/default-disk.blp
+++ b/bootc_installer/gtk/default-disk.blp
@@ -119,6 +119,15 @@ template $VanillaDefaultDisk: Adw.Bin {
             visible: false;
           }
 
+          Adw.Banner fs_tool_error_banner {
+            visible: false;
+            button-label: "";
+
+            styles [
+              "error",
+            ]
+          }
+
           Adw.EntryRow hostname_entry {
             title: _("Hostname");
             text: "localhost";

--- a/bootc_installer/gtk/widget-page-header.blp
+++ b/bootc_installer/gtk/widget-page-header.blp
@@ -6,11 +6,7 @@ template $TunaPageHeader: Gtk.Box {
   halign: center;
 
   Image _icon {
-    pixel-size: 96;
-
-    styles [
-      "dim-label",
-    ]
+    pixel-size: 128;
   }
 
   Box {

--- a/bootc_installer/gtk/window.blp
+++ b/bootc_installer/gtk/window.blp
@@ -31,9 +31,9 @@ template $VanillaWindow: Adw.ApplicationWindow {
         };
 
         [end]
-        Button btn_about {
-          icon-name: "help-about-symbolic";
-          tooltip-text: _("About");
+        Button btn_exit {
+          icon-name: "window-close-symbolic";
+          tooltip-text: _("Exit Installer");
 
           styles [
             "flat",
@@ -41,9 +41,9 @@ template $VanillaWindow: Adw.ApplicationWindow {
         }
 
         [end]
-        Button btn_exit {
-          icon-name: "window-close-symbolic";
-          tooltip-text: _("Exit Installer");
+        Button btn_about {
+          icon-name: "help-about-symbolic";
+          tooltip-text: _("About");
 
           styles [
             "flat",

--- a/bootc_installer/utils/builder.py
+++ b/bootc_installer/utils/builder.py
@@ -150,4 +150,5 @@ class Builder:
             "name": self.__recipe.raw["distro_name"],
             "logo": self.__recipe.raw["distro_logo"],
             "default_image_icon": default_image_icon,
+            "welcome_title": self.__recipe.raw.get("welcome_title", ""),
         }

--- a/recipe.json
+++ b/recipe.json
@@ -2,6 +2,7 @@
     "log_file": "/var/log/bootc-installer.log",
     "distro_name": "TunaOS",
     "distro_logo": "org.bootcinstaller.Installer",
+    "welcome_title": "Welcome to TunaOS!",
     "tour": {
         "welcome": {
             "resource": "/org/bootcinstaller/Installer/assets/welcome.png",

--- a/recipe.json
+++ b/recipe.json
@@ -2,7 +2,7 @@
     "log_file": "/var/log/bootc-installer.log",
     "distro_name": "TunaOS",
     "distro_logo": "org.bootcinstaller.Installer",
-    "welcome_title": "Welcome to TunaOS!",
+    "welcome_title": "",
     "tour": {
         "welcome": {
             "resource": "/org/bootcinstaller/Installer/assets/welcome.png",

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -229,7 +229,7 @@ class TestDiskStepFsToolCheck:
         return widget
 
     def test_banner_shown_when_xfs_tool_missing(self):
-        """fs_tool_error_banner becomes visible when mkfs.xfs is not on the host PATH."""
+        """fs_tool_error_banner becomes visible and row turns red when mkfs.xfs is missing."""
         import subprocess
         from unittest.mock import patch
 
@@ -244,9 +244,13 @@ class TestDiskStepFsToolCheck:
             "fs_tool_error_banner should be visible when mkfs.xfs is missing"
         )
         assert "xfsprogs" in widget.fs_tool_error_banner.get_title()
+        assert widget.filesystem_row.has_css_class("error"), (
+            "filesystem_row should have 'error' CSS class when mkfs.xfs is missing"
+        )
+        assert "xfsprogs" in widget.filesystem_row.get_subtitle()
 
     def test_banner_hidden_when_xfs_tool_present(self):
-        """fs_tool_error_banner stays hidden when mkfs.xfs is available on the host."""
+        """Banner hidden and row error class cleared when mkfs.xfs is available."""
         import subprocess
         from unittest.mock import patch
 
@@ -260,9 +264,13 @@ class TestDiskStepFsToolCheck:
         assert not widget.fs_tool_error_banner.get_visible(), (
             "fs_tool_error_banner should be hidden when mkfs.xfs is available"
         )
+        assert not widget.filesystem_row.has_css_class("error"), (
+            "filesystem_row should not have 'error' CSS class when mkfs.xfs is available"
+        )
+        assert widget.filesystem_row.get_subtitle() == ""
 
     def test_banner_shown_when_btrfs_tool_missing(self):
-        """fs_tool_error_banner becomes visible when mkfs.btrfs is not on the host PATH."""
+        """fs_tool_error_banner visible and row red when mkfs.btrfs is missing."""
         import subprocess
         from unittest.mock import patch
 
@@ -277,6 +285,8 @@ class TestDiskStepFsToolCheck:
             "fs_tool_error_banner should be visible when mkfs.btrfs is missing"
         )
         assert "btrfs-progs" in widget.fs_tool_error_banner.get_title()
+        assert widget.filesystem_row.has_css_class("error")
+        assert "btrfs-progs" in widget.filesystem_row.get_subtitle()
 
     def test_btn_next_blocked_when_tool_missing(self):
         """btn_next must be insensitive when the required mkfs tool is missing."""

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -278,6 +278,42 @@ class TestDiskStepFsToolCheck:
         )
         assert "btrfs-progs" in widget.fs_tool_error_banner.get_title()
 
+    def test_btn_next_blocked_when_tool_missing(self):
+        """btn_next must be insensitive when the required mkfs tool is missing."""
+        import subprocess
+        from unittest.mock import patch
+
+        widget = self._make_disk_widget()
+        # Simulate a partition recipe being set (as if the user picked a disk)
+        widget._VanillaDefaultDisk__partition_recipe = {"disk": "/dev/sda"}
+
+        missing = subprocess.CompletedProcess(args=[], returncode=1)
+        with patch("subprocess.run", return_value=missing):
+            widget._VanillaDefaultDisk__check_fs_tool("xfs")
+            _pump()
+
+        assert not widget.btn_next.get_sensitive(), (
+            "btn_next must be insensitive when mkfs.xfs is missing from host PATH"
+        )
+
+    def test_btn_next_unblocked_when_tool_present(self):
+        """btn_next becomes sensitive when tool is present and a partition recipe exists."""
+        import subprocess
+        from unittest.mock import patch
+
+        widget = self._make_disk_widget()
+        widget._VanillaDefaultDisk__partition_recipe = {"disk": "/dev/sda"}
+
+        present = subprocess.CompletedProcess(args=[], returncode=0)
+        with patch("subprocess.run", return_value=present):
+            widget._VanillaDefaultDisk__check_fs_tool("xfs")
+            _pump()
+
+        assert widget.btn_next.get_sensitive(), (
+            "btn_next must be sensitive when mkfs.xfs is present and a partition recipe exists"
+        )
+
+
 
 class TestWizardNavigation:
     def test_can_advance_from_image_step(self, window):

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -202,6 +202,78 @@ class TestDiskStepButtonState:
         )
 
 
+class TestDiskStepFsToolCheck:
+    """fs_tool_error_banner shows when the required mkfs tool is missing on the host."""
+
+    def _make_disk_widget(self):
+        from unittest.mock import MagicMock, patch
+
+        from bootc_installer.defaults.disk import VanillaDefaultDisk
+        from bootc_installer.widgets.page_header import TunaPageHeader  # noqa: F401 — registers GType
+
+        mock_window = MagicMock()
+        mock_window.recipe = {"min_disk_size": 51200}
+        mock_window.image_step.get_finals.return_value = {
+            "supported_filesystems": ["xfs", "btrfs"],
+            "default_hostname": "",
+        }
+        with patch("bootc_installer.defaults.disk.DisksManager") as MockDM:
+            MockDM.return_value.all_disks.return_value = []
+            widget = VanillaDefaultDisk(mock_window, {}, "disk", {})
+            _pump()
+        return widget
+
+    def test_banner_shown_when_xfs_tool_missing(self):
+        """fs_tool_error_banner becomes visible when mkfs.xfs is not on the host PATH."""
+        import subprocess
+        from unittest.mock import patch
+
+        widget = self._make_disk_widget()
+
+        missing = subprocess.CompletedProcess(args=[], returncode=1)
+        with patch("subprocess.run", return_value=missing):
+            widget._VanillaDefaultDisk__check_fs_tool("xfs")
+            _pump()
+
+        assert widget.fs_tool_error_banner.get_visible(), (
+            "fs_tool_error_banner should be visible when mkfs.xfs is missing"
+        )
+        assert "xfsprogs" in widget.fs_tool_error_banner.get_title()
+
+    def test_banner_hidden_when_xfs_tool_present(self):
+        """fs_tool_error_banner stays hidden when mkfs.xfs is available on the host."""
+        import subprocess
+        from unittest.mock import patch
+
+        widget = self._make_disk_widget()
+
+        present = subprocess.CompletedProcess(args=[], returncode=0)
+        with patch("subprocess.run", return_value=present):
+            widget._VanillaDefaultDisk__check_fs_tool("xfs")
+            _pump()
+
+        assert not widget.fs_tool_error_banner.get_visible(), (
+            "fs_tool_error_banner should be hidden when mkfs.xfs is available"
+        )
+
+    def test_banner_shown_when_btrfs_tool_missing(self):
+        """fs_tool_error_banner becomes visible when mkfs.btrfs is not on the host PATH."""
+        import subprocess
+        from unittest.mock import patch
+
+        widget = self._make_disk_widget()
+
+        missing = subprocess.CompletedProcess(args=[], returncode=1)
+        with patch("subprocess.run", return_value=missing):
+            widget._VanillaDefaultDisk__check_fs_tool("btrfs")
+            _pump()
+
+        assert widget.fs_tool_error_banner.get_visible(), (
+            "fs_tool_error_banner should be visible when mkfs.btrfs is missing"
+        )
+        assert "btrfs-progs" in widget.fs_tool_error_banner.get_title()
+
+
 class TestWizardNavigation:
     def test_can_advance_from_image_step(self, window):
         """Clicking Next on the image step rebuilds downstream UI and advances."""

--- a/tests/ui/test_wizard.py
+++ b/tests/ui/test_wizard.py
@@ -211,6 +211,11 @@ class TestDiskStepFsToolCheck:
         from bootc_installer.defaults.disk import VanillaDefaultDisk
         from bootc_installer.widgets.page_header import TunaPageHeader  # noqa: F401 — registers GType
 
+        try:
+            Adw.ButtonRow  # noqa: B018 — probe for ≥1.6 widget used in VanillaDefaultDisk.__init__
+        except AttributeError:
+            pytest.skip("Adw.ButtonRow requires libadwaita >= 1.6")
+
         mock_window = MagicMock()
         mock_window.recipe = {"min_disk_size": 51200}
         mock_window.image_step.get_finals.return_value = {

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -26,7 +26,11 @@ def _auto_finals(disk="/dev/vda", fs="xfs", image="ghcr.io/tuna-os/yellowfin:gno
                  composefs=False, image_type="bootc", bootloader="", image_filesystem="",
                  flatpak_var_path=""):
     d = {
-        "disk": {"auto": {"disk": disk, "pretty_size": "100 GB", "size": 100_000_000_000}},
+        "disk": {
+            "auto": {"disk": disk, "pretty_size": "100 GB", "size": 100_000_000_000},
+            "filesystem": fs,
+            "btrfsSubvolumes": fs == "btrfs",
+        },
         "selected_image": image,
         "hostname": hostname,
         "flatpaks": flatpaks or [],
@@ -99,7 +103,7 @@ class TestAutoDisk:
                    "encryption": {"use_encryption": False}}]
         path = Processor.gen_install_recipe("log", finals, _SYS_RECIPE)
         r = _load(path)
-        assert r["hostname"] == "tunaos"
+        assert r["hostname"] == "tunaos"  # sys recipe still provides distro_name fallback
 
 
 # ── Encryption tests ───────────────────────────────────────────────────────────
@@ -304,6 +308,23 @@ class TestComposefs:
             "log", _auto_finals(fs="xfs", image_filesystem=""), _SYS_RECIPE)
         r = _load(path)
         assert r["filesystem"] == "xfs"
+
+    def test_disk_step_btrfs_selection(self):
+        # When the disk step picks btrfs (user chose it from filesystem dropdown),
+        # the recipe must reflect btrfs + subvolumes=True.
+        path = Processor.gen_install_recipe(
+            "log", _auto_finals(fs="btrfs"), _SYS_RECIPE)
+        r = _load(path)
+        assert r["filesystem"] == "btrfs"
+        assert r["btrfsSubvolumes"] is True
+
+    def test_disk_step_xfs_no_subvolumes(self):
+        # XFS selection must never set btrfsSubvolumes=True.
+        path = Processor.gen_install_recipe(
+            "log", _auto_finals(fs="xfs"), _SYS_RECIPE)
+        r = _load(path)
+        assert r["filesystem"] == "xfs"
+        assert r.get("btrfsSubvolumes", False) is False
 
     def test_dakota_recipe_fields(self):
         """Simulate a Dakota image selection producing the full expected recipe."""


### PR DESCRIPTION
Promote the current `dev` branch to `prod` so the production installer Flatpak picks up the latest merged installer and fisherman changes.